### PR TITLE
Provide user options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0
+
+### Added
+
+- Support user-configuration rooted at `jedi`. Only 1 option for now: `jedi.completion.triggerCharacters`. Same defaults as version `0.6.1`.
+- Message flashes after initialization.
+
+### Changed
+
+- `pygls` types now checked. Version `0.9.0` provides type-hint checking support.
+
 ## 0.6.1
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jedi-language-server aims to support all of Jedi's capabilities and expose them 
 
 These language server requests are not currently configurable by the user, but we expect to relax this constraint in a future release.
 
-## Usage
+## Setup
 
 The following instructions show how to use jedi-language-server with your development tooling. The instructions assume you have already installed jedi-language-server.
 
@@ -56,7 +56,7 @@ Configure jedi-language-server with [coc.nvim](https://github.com/neoclide/coc.n
 
 ```json
 "languageserver": {
-  "jls": {
+  "jedi": {
     "command": "jedi-language-server",
     "args": [],
     "filetypes": ["python"]
@@ -98,6 +98,23 @@ Configure jedi-language-server with [coc.nvim](https://github.com/neoclide/coc.n
     "offsetColumn": 1,
     "formatLines": 1
   }
+}
+```
+
+## Configuration
+
+jedi-language-server supports the following top-level configuration items in your `settings.json` or editor-equivalent configuration file:
+
+`jedi.completion.triggerCharacters`: characters that trigger completion automatically when typed
+
+- type: `array<string>`
+- default: `[".", "'", "\""]`
+
+Example `settings.json` with defaults:
+
+```json
+{
+  "jedi.completion.triggerCharacters": [".", "'", "\""]
 }
 ```
 

--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -21,11 +21,11 @@ from pygls.workspace import Workspace
 from .type_map import get_lsp_symbol_type
 
 
-def get_script(
+def script(
     workspace: Workspace, text_document_identifier: TextDocumentIdentifier
 ) -> Script:
     """Simplifies getting jedi Script"""
-    project = get_project(workspace)
+    project = project(workspace)
     document = workspace.get_document(text_document_identifier.uri)
     return Script(
         code=document.source,
@@ -35,7 +35,7 @@ def get_script(
     )
 
 
-def get_project(workspace: Workspace) -> Project:
+def project(workspace: Workspace) -> Project:
     """Simplifies getting jedi project"""
     return Project(
         path=workspace.root_path,
@@ -44,7 +44,7 @@ def get_project(workspace: Workspace) -> Project:
     )
 
 
-def get_lsp_location(name: Name) -> Location:
+def lsp_location(name: Name) -> Location:
     """Get LSP location from Jedi definition
 
     NOTE:
@@ -63,17 +63,17 @@ def get_lsp_location(name: Name) -> Location:
     )
 
 
-def get_lsp_symbol_information(name: Name) -> SymbolInformation:
+def lsp_symbol_information(name: Name) -> SymbolInformation:
     """Get LSP SymbolInformation from Jedi definition"""
     return SymbolInformation(
         name=name.name,
         kind=get_lsp_symbol_type(name.type),
-        location=get_lsp_location(name),
-        container_name=get_parent_name(name),
+        location=lsp_location(name),
+        container_name=parent_name(name),
     )
 
 
-def get_parent_name(name: Name) -> Optional[str]:
+def parent_name(name: Name) -> Optional[str]:
     """Retrieve the parent name from Jedi
 
     Error prone Jedi calls are wrapped in try/except to avoid
@@ -85,7 +85,7 @@ def get_parent_name(name: Name) -> Optional[str]:
     return parent.name if parent and parent.parent() else None
 
 
-def get_line_column(position: Position) -> Dict[str, int]:
+def line_column(position: Position) -> Dict[str, int]:
     """Translate pygls Position to Jedi's line / column
 
     Returns a dictionary because this return result should be unpacked as a

--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -1,11 +1,13 @@
-"""Utility functions used by the language server"""
+"""Utilities to work with Jedi
+
+Translates pygls types back and forth with Jedi
+"""
 
 from typing import Dict, Optional
 
 from jedi import Project, Script
 from jedi.api.classes import Name
 from jedi.api.environment import get_cached_default_environment
-from pygls.server import LanguageServer
 from pygls.types import (
     Location,
     Position,
@@ -14,21 +16,17 @@ from pygls.types import (
     TextDocumentIdentifier,
 )
 from pygls.uris import from_fs_path
+from pygls.workspace import Workspace
 
 from .type_map import get_lsp_symbol_type
 
 
 def get_jedi_script(
-    server: LanguageServer, text_document_identifier: TextDocumentIdentifier
+    workspace: Workspace, text_document_identifier: TextDocumentIdentifier
 ) -> Script:
     """Simplifies getting jedi Script"""
-    workspace = server.workspace
+    project = get_jedi_project(workspace)
     document = workspace.get_document(text_document_identifier.uri)
-    project = Project(
-        path=workspace.root_path,
-        smart_sys_path=True,
-        load_unsafe_extensions=False,
-    )
     return Script(
         code=document.source,
         path=document.path,
@@ -37,9 +35,8 @@ def get_jedi_script(
     )
 
 
-def get_jedi_project(server: LanguageServer) -> Project:
+def get_jedi_project(workspace: Workspace) -> Project:
     """Simplifies getting jedi project"""
-    workspace = server.workspace
     return Project(
         path=workspace.root_path,
         smart_sys_path=True,

--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -25,12 +25,12 @@ def script(
     workspace: Workspace, text_document_identifier: TextDocumentIdentifier
 ) -> Script:
     """Simplifies getting jedi Script"""
-    project = project(workspace)
+    project_ = project(workspace)
     document = workspace.get_document(text_document_identifier.uri)
     return Script(
         code=document.source,
         path=document.path,
-        project=project,
+        project=project_,
         environment=get_cached_default_environment(),
     )
 

--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -21,11 +21,11 @@ from pygls.workspace import Workspace
 from .type_map import get_lsp_symbol_type
 
 
-def get_jedi_script(
+def get_script(
     workspace: Workspace, text_document_identifier: TextDocumentIdentifier
 ) -> Script:
     """Simplifies getting jedi Script"""
-    project = get_jedi_project(workspace)
+    project = get_project(workspace)
     document = workspace.get_document(text_document_identifier.uri)
     return Script(
         code=document.source,
@@ -35,7 +35,7 @@ def get_jedi_script(
     )
 
 
-def get_jedi_project(workspace: Workspace) -> Project:
+def get_project(workspace: Workspace) -> Project:
     """Simplifies getting jedi project"""
     return Project(
         path=workspace.root_path,
@@ -44,7 +44,7 @@ def get_jedi_project(workspace: Workspace) -> Project:
     )
 
 
-def get_location_from_name(name: Name) -> Location:
+def get_lsp_location(name: Name) -> Location:
     """Get LSP location from Jedi definition
 
     NOTE:
@@ -63,17 +63,17 @@ def get_location_from_name(name: Name) -> Location:
     )
 
 
-def get_symbol_information_from_name(name: Name,) -> SymbolInformation:
+def get_lsp_symbol_information(name: Name) -> SymbolInformation:
     """Get LSP SymbolInformation from Jedi definition"""
     return SymbolInformation(
         name=name.name,
         kind=get_lsp_symbol_type(name.type),
-        location=get_location_from_name(name),
-        container_name=get_jedi_parent_name(name),
+        location=get_lsp_location(name),
+        container_name=get_parent_name(name),
     )
 
 
-def get_jedi_parent_name(name: Name) -> Optional[str]:
+def get_parent_name(name: Name) -> Optional[str]:
     """Retrieve the parent name from Jedi
 
     Error prone Jedi calls are wrapped in try/except to avoid
@@ -85,7 +85,7 @@ def get_jedi_parent_name(name: Name) -> Optional[str]:
     return parent.name if parent and parent.parent() else None
 
 
-def get_jedi_line_column(position: Position) -> Dict[str, int]:
+def get_line_column(position: Position) -> Dict[str, int]:
     """Translate pygls Position to Jedi's line / column
 
     Returns a dictionary because this return result should be unpacked as a

--- a/jedi_language_server/pygls_utils.py
+++ b/jedi_language_server/pygls_utils.py
@@ -5,12 +5,30 @@ Helper functions that simplify working with pygls
 
 
 import functools
+from typing import Callable, NamedTuple, Tuple
 from uuid import uuid4
 
+from pygls.server import LanguageServer
 from pygls.types import Position
 from pygls.workspace import Document
 
 _SENTINEL = object()
+
+
+class FeatureConfig(NamedTuple):
+    """Configuration for a feature"""
+
+    arg: str
+    path: str
+    default: object
+
+
+class Feature(NamedTuple):
+    """Organize information about LanguageServer features"""
+
+    lsp_method: str
+    function: Callable[[LanguageServer, object], object]
+    config: Tuple[FeatureConfig, ...] = tuple()
 
 
 def rgetattr(obj: object, attr: str, default: object = None) -> object:

--- a/jedi_language_server/pygls_utils.py
+++ b/jedi_language_server/pygls_utils.py
@@ -5,6 +5,10 @@ Helper functions that simplify working with pygls
 
 
 import functools
+from uuid import uuid4
+
+from pygls.types import Position
+from pygls.workspace import Document
 
 _SENTINEL = object()
 
@@ -22,3 +26,30 @@ def _rgetattr(obj: object, attr: str):
         return getattr(obj, attr, _SENTINEL)
 
     return functools.reduce(_getattr, [obj] + attr.split("."))
+
+
+def clean_completion_name(name: str, char: str) -> str:
+    """Clean the completion name, stripping bad surroundings
+
+    1. Remove all surrounding " and '. For
+    """
+    if char == "'":
+        return name.lstrip("'")
+    if char == '"':
+        return name.lstrip('"')
+    return name
+
+
+def char_before_cursor(
+    document: Document, position: Position, default=""
+) -> str:
+    """Get the character directly before the cursor"""
+    try:
+        return document.lines[position.line][position.character - 1]
+    except IndexError:
+        return default
+
+
+def uuid() -> str:
+    """Function to create a string uuid"""
+    return str(uuid4())

--- a/jedi_language_server/pygls_utils.py
+++ b/jedi_language_server/pygls_utils.py
@@ -1,0 +1,24 @@
+"""Utilities to work with pygls
+
+Helper functions that simplify working with pygls
+"""
+
+
+import functools
+
+_SENTINEL = object()
+
+
+def rgetattr(obj: object, attr: str, default: object = None) -> object:
+    """Get nested attributes, recursively"""
+    result = _rgetattr(obj, attr)
+    return default if result is _SENTINEL else result
+
+
+def _rgetattr(obj: object, attr: str):
+    """Get nested attributes, recursively"""
+
+    def _getattr(obj, attr):
+        return getattr(obj, attr, _SENTINEL)
+
+    return functools.reduce(_getattr, [obj] + attr.split("."))

--- a/jedi_language_server/pygls_utils.py
+++ b/jedi_language_server/pygls_utils.py
@@ -15,7 +15,31 @@ _SENTINEL = object()
 
 
 class FeatureConfig(NamedTuple):
-    """Configuration for a feature"""
+    """Configuration item for a feature with associated defaults
+
+    :attr arg: the name of the option within the feature
+    :attr path: the lookup path, rooted at `jedi`, to the user configuration
+    :attr default: the value used if no value is found in the path
+
+    Example:
+
+        settings.json:
+
+        {
+          "jedi.completion.triggerCharacters": [".", "'", "\""]
+        }
+
+        python code associated with this configuration:
+
+        FeatureConfig(
+            "triggerCharacters",
+            "completion.triggerCharacters",
+            [".", "'", '"'],
+        )
+
+    NOTE: all paths are rooted at "jedi". Do not specify the top-level jedi in
+    the path.
+    """
 
     arg: str
     path: str
@@ -23,7 +47,12 @@ class FeatureConfig(NamedTuple):
 
 
 class Feature(NamedTuple):
-    """Organize information about LanguageServer features"""
+    """Organize information about LanguageServer features
+
+    :attr lsp_method: exact name of the feature's LSP method
+    :attr function: python function to be associated with the method
+    :attr config: collection of FeatureConfig supported by this feature
+    """
 
     lsp_method: str
     function: Callable
@@ -31,7 +60,18 @@ class Feature(NamedTuple):
 
 
 def rgetattr(obj: object, attr: str, default: object = None) -> object:
-    """Get nested attributes, recursively"""
+    """Get nested attributes, recursively
+
+    Usage:
+        >> repr(my_object)
+            Object(hello=Object(world=2))
+        >> rgetattr(my_object, "hello.world")
+            2
+        >> rgetattr(my_object, "hello.world.space")
+            None
+        >> rgetattr(my_object, "hello.world.space", 20)
+            20
+    """
     result = _rgetattr(obj, attr)
     return default if result is _SENTINEL else result
 

--- a/jedi_language_server/pygls_utils.py
+++ b/jedi_language_server/pygls_utils.py
@@ -8,7 +8,6 @@ import functools
 from typing import Callable, NamedTuple, Tuple
 from uuid import uuid4
 
-from pygls.server import LanguageServer
 from pygls.types import Position
 from pygls.workspace import Document
 
@@ -27,7 +26,7 @@ class Feature(NamedTuple):
     """Organize information about LanguageServer features"""
 
     lsp_method: str
-    function: Callable[[LanguageServer, object], object]
+    function: Callable
     config: Tuple[FeatureConfig, ...] = tuple()
 
 
@@ -37,13 +36,13 @@ def rgetattr(obj: object, attr: str, default: object = None) -> object:
     return default if result is _SENTINEL else result
 
 
-def _rgetattr(obj: object, attr: str):
+def _rgetattr(obj: object, attr: str) -> object:
     """Get nested attributes, recursively"""
 
     def _getattr(obj, attr):
         return getattr(obj, attr, _SENTINEL)
 
-    return functools.reduce(_getattr, [obj] + attr.split("."))
+    return functools.reduce(_getattr, [obj] + attr.split("."))  # type: ignore
 
 
 def clean_completion_name(name: str, char: str) -> str:

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -8,9 +8,10 @@ Official language server spec:
 
 import itertools
 import uuid
-from typing import Dict  # pylint: disable=unused-import
-from typing import List, NamedTuple, Optional
+from collections import defaultdict
+from typing import Callable, Dict, List, NamedTuple, Optional
 
+from pygls.exceptions import FeatureAlreadyRegisteredError
 from pygls.features import (
     COMPLETION,
     DEFINITION,
@@ -26,6 +27,8 @@ from pygls.types import (
     CompletionItem,
     CompletionList,
     CompletionParams,
+    ConfigurationItem,
+    ConfigurationParams,
     DocumentSymbolParams,
     Hover,
     InitializeParams,
@@ -38,71 +41,15 @@ from pygls.types import (
     SymbolInformation,
     TextDocumentPositionParams,
     TextEdit,
+    Unregistration,
+    UnregistrationParams,
     WorkspaceEdit,
     WorkspaceSymbolParams,
 )
 from pygls.workspace import Document
 
-from . import jedi_utils
+from . import jedi_utils, pygls_utils
 from .type_map import get_lsp_completion_type
-
-SERVER = LanguageServer()
-
-
-class Option(NamedTuple):
-    name_user: str
-    name_system: str
-    default: object
-
-
-class ServerConfig:
-    def __init__(
-        self, server: LanguageServer, initialization_options: object
-    ) -> None:
-        self.server = server
-        self.init_options = initialization_options
-
-    def get_options(self, options: List[Option]) -> Dict[str, object]:
-        """Obtain the object provided by the default"""
-        return {
-            option.name_system: getattr(
-                self.init_options, option.name_user, option.default
-            )
-            for option in options
-        }
-
-    async def register(self, method: str, options: List[Option]) -> None:
-        response = await self.server.register_capability_async(
-            RegistrationParams(
-                [
-                    Registration(
-                        str(uuid.uuid4()), method, self.get_options(options)
-                    )
-                ]
-            )
-        )
-        if response is not None:
-            self.server.show_message(
-                f"jedi-language-server: error during {method} registration",
-                MessageType.Error,
-            )
-
-
-@SERVER.feature(INITIALIZED)
-async def lsp_initialize(server: LanguageServer, params: InitializeParams):
-    """Initialize language server"""
-    config = ServerConfig(server, params.initializationOptions)
-    await config.register(
-        COMPLETION,
-        [
-            Option(
-                name_user="completion_triggerCharacters",
-                name_system="triggerCharacters",
-                default=[".", "'", '"'],
-            )
-        ],
-    )
-    server.show_message("jedi-language-server: registration complete")
 
 
 def _clean_completion_name(name: str, char: str) -> str:
@@ -127,8 +74,155 @@ def _char_before_cursor(
         return default
 
 
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+class JediLanguageServer(LanguageServer):
+    """The Jedi Language Server"""
+
+    lookup_feature_id = defaultdict(_uuid)  # type: Dict[str, str]
+
+    async def re_register_feature(
+        self,
+        feature_name: str,
+        callback: Callable,
+        config_section: str,
+        options: Dict[str, str],
+    ):
+        """Unregister and register feature with new options"""
+        if feature_name in self.lookup_feature_id:
+            params = UnregistrationParams(
+                [
+                    Unregistration(
+                        self.lookup_feature_id[feature_name], feature_name
+                    )
+                ]
+            )
+            await self.unregister_capability_async(params)
+        config = await self.get_configuration_async(
+            ConfigurationParams([ConfigurationItem(section=config_section)])
+        )
+
+        registration_options = {
+            name: getattr(config[0], name, default)
+            for name, default in options.items()
+        } if config else {}
+        register_params = RegistrationParams(
+            [
+                Registration(
+                    self.lookup_feature_id[feature_name],
+                    feature_name,
+                    registration_options,
+                )
+            ]
+        )
+        response = await self.register_capability_async(register_params)
+        if response is None:
+            try:
+                self.feature(feature_name)(callback)
+            except FeatureAlreadyRegisteredError:
+                pass
+
+    # @SERVER.feature(COMPLETION)
+
+    # @SERVER.feature(HOVER)
+    def feature_hover(self, params: TextDocumentPositionParams) -> Hover:
+        """Support Hover"""
+        jedi_script = jedi_utils.script(server.workspace, params.textDocument)
+        jedi_lines = jedi_utils.line_column(params.position)
+        try:
+            _names = jedi_script.help(**jedi_lines)
+        except Exception:  # pylint: disable=broad-except
+            names = []  # type: List[str]
+        else:
+            names = [name for name in (n.docstring() for n in _names) if name]
+        return Hover(contents=names if names else "jedi: no help docs found")
+
+    # @SERVER.feature(REFERENCES)
+    def feature_references(
+        self, params: TextDocumentPositionParams
+    ) -> List[Location]:
+        """Obtain all references to document"""
+        jedi_script = jedi_utils.script(server.workspace, params.textDocument)
+        jedi_lines = jedi_utils.line_column(params.position)
+        try:
+            names = jedi_script.get_references(**jedi_lines)
+        except Exception:  # pylint: disable=broad-except
+            return []
+        return [jedi_utils.lsp_location(name) for name in names]
+
+    # @SERVER.feature(RENAME)
+    def feature_rename(self, params: RenameParams) -> Optional[WorkspaceEdit]:
+        """Rename a symbol across a workspace"""
+        jedi_script = jedi_utils.script(server.workspace, params.textDocument)
+        jedi_lines = jedi_utils.line_column(params.position)
+        try:
+            names = jedi_script.get_references(**jedi_lines)
+        except Exception:  # pylint: disable=broad-except
+            return None
+        locations = [jedi_utils.lsp_location(name) for name in names]
+        if not locations:
+            return None
+        changes = {}  # type: Dict[str, List[TextEdit]]
+        for location in locations:
+            text_edit = TextEdit(location.range, new_text=params.newName)
+            if location.uri not in changes:
+                changes[location.uri] = [text_edit]
+            else:
+                changes[location.uri].append(text_edit)
+        return WorkspaceEdit(changes=changes)
+
+    # @SERVER.feature(DOCUMENT_SYMBOL)
+    def feature_document_symbol(
+        self, params: DocumentSymbolParams
+    ) -> List[SymbolInformation]:
+        """Document Python document symbols"""
+        jedi_script = jedi_utils.script(server.workspace, params.textDocument)
+        try:
+            names = jedi_script.get_names()
+        except Exception:  # pylint: disable=broad-except
+            return []
+        return [jedi_utils.lsp_symbol_information(name) for name in names]
+
+    # @SERVER.feature(WORKSPACE_SYMBOL)
+    def feature_workspace_symbol(
+        self, params: WorkspaceSymbolParams
+    ) -> List[SymbolInformation]:
+        """Document Python workspace symbols"""
+        jedi_project = jedi_utils.project(server.workspace)
+        if params.query.strip() == "":
+            return []
+        try:
+            names = jedi_project.search(params.query)
+        except Exception:  # pylint: disable=broad-except
+            return []
+        return [
+            jedi_utils.lsp_symbol_information(name)
+            for name in itertools.islice(names, 20)
+        ]
+
+
+SERVER = JediLanguageServer()
+
+
+@SERVER.feature(INITIALIZED)
+async def feature_initialized(server: JediLanguageServer, params):
+    """Register features that could be changed in the future"""
+    # server.show_message("entered")
+    await server.re_register_feature(
+        COMPLETION,
+        completion,
+        "jls.completion",
+        {"triggerCharacters": [".", "'", '"']},
+    )
+    # server.show_message("done")
+
+
 @SERVER.feature(COMPLETION)
-def lsp_completion(server: LanguageServer, params: CompletionParams):
+def completion(
+    server: JediLanguageServer, params: CompletionParams
+) -> CompletionList:
     """Returns completion items"""
     jedi_script = jedi_utils.script(server.workspace, params.textDocument)
     jedi_lines = jedi_utils.line_column(params.position)
@@ -153,8 +247,8 @@ def lsp_completion(server: LanguageServer, params: CompletionParams):
 
 
 @SERVER.feature(DEFINITION)
-def lsp_definition(
-    server: LanguageServer, params: TextDocumentPositionParams
+def definition(
+    server: JediLanguageServer, params: TextDocumentPositionParams
 ) -> List[Location]:
     """Support Goto Definition"""
     jedi_script = jedi_utils.script(server.workspace, params.textDocument)
@@ -165,86 +259,85 @@ def lsp_definition(
     return [jedi_utils.lsp_location(name) for name in names]
 
 
-@SERVER.feature(HOVER)
-def lsp_hover(
-    server: LanguageServer, params: TextDocumentPositionParams
-) -> Hover:
-    """Support Hover"""
-    jedi_script = jedi_utils.script(server.workspace, params.textDocument)
-    jedi_lines = jedi_utils.line_column(params.position)
-    try:
-        _names = jedi_script.help(**jedi_lines)
-    except Exception:  # pylint: disable=broad-except
-        names = []  # type: List[str]
-    else:
-        names = [name for name in (n.docstring() for n in _names) if name]
-    return Hover(contents=names if names else "jedi: no help docs found")
+# SERVER = LanguageServer()
 
 
-@SERVER.feature(REFERENCES)
-def lsp_references(
-    server: LanguageServer, params: TextDocumentPositionParams
-) -> List[Location]:
-    """Obtain all references to document"""
-    jedi_script = jedi_utils.script(server.workspace, params.textDocument)
-    jedi_lines = jedi_utils.line_column(params.position)
-    try:
-        names = jedi_script.get_references(**jedi_lines)
-    except Exception:  # pylint: disable=broad-except
-        return []
-    return [jedi_utils.lsp_location(name) for name in names]
+# class Option(NamedTuple):
+#     name_user: str
+#     name_system: str
+#     default: object
 
 
-@SERVER.feature(RENAME)
-def lsp_rename(
-    server: LanguageServer, params: RenameParams
-) -> Optional[WorkspaceEdit]:
-    """Rename a symbol across a workspace"""
-    jedi_script = jedi_utils.script(server.workspace, params.textDocument)
-    jedi_lines = jedi_utils.line_column(params.position)
-    try:
-        names = jedi_script.get_references(**jedi_lines)
-    except Exception:  # pylint: disable=broad-except
-        return None
-    locations = [jedi_utils.lsp_location(name) for name in names]
-    if not locations:
-        return None
-    changes = {}  # type: Dict[str, List[TextEdit]]
-    for location in locations:
-        text_edit = TextEdit(location.range, new_text=params.newName)
-        if location.uri not in changes:
-            changes[location.uri] = [text_edit]
-        else:
-            changes[location.uri].append(text_edit)
-    return WorkspaceEdit(changes=changes)
+# class ServerConfig:
+#     async def re_register_completions(self):
+#         """Unregister and register completions with new options."""
+#         config = await self.get_configuration_async(
+#             ConfigurationParams(
+#                 [
+#                     ConfigurationItem(
+#                         "", JsonLanguageServer.CONFIGURATION_SECTION
+#                     )
+#                 ]
+#             )
+#         )
 
+#         trigger_chars = config[0].triggerCharacters
+#         # register completions
+#         await self.re_register_feature(
+#             self.COMPLETION_ID,
+#             self.completions,
+#             COMPLETION,
+#             **dict(triggerCharacters=trigger_chars),
+#         )
+#         self.show_message(
+#             "Completion trigger characters are: {}".format(
+#                 " ".join(trigger_chars)
+#             )
+#         )
 
-@SERVER.feature(DOCUMENT_SYMBOL)
-def lsp_document_symbol(
-    server: LanguageServer, params: DocumentSymbolParams
-) -> List[SymbolInformation]:
-    """Document Python document symbols"""
-    jedi_script = jedi_utils.script(server.workspace, params.textDocument)
-    try:
-        names = jedi_script.get_names()
-    except Exception:  # pylint: disable=broad-except
-        return []
-    return [jedi_utils.lsp_symbol_information(name) for name in names]
+#     def __init__(
+#         self, server: LanguageServer, initialization_options: object
+#     ) -> None:
+#         self.server = server
+#         self.init_options = initialization_options
 
+#     def get_options(self, options: List[Option]) -> Dict[str, object]:
+#         """Obtain the object provided by the default"""
+#         return {
+#             option.name_system: getattr(
+#                 self.init_options, option.name_user, option.default
+#             )
+#             for option in options
+#         }
 
-@SERVER.feature(WORKSPACE_SYMBOL)
-def lsp_workspace_symbol(
-    server: LanguageServer, params: WorkspaceSymbolParams
-) -> List[SymbolInformation]:
-    """Document Python workspace symbols"""
-    jedi_project = jedi_utils.project(server.workspace)
-    if params.query.strip() == "":
-        return []
-    try:
-        names = jedi_project.search(params.query)
-    except Exception:  # pylint: disable=broad-except
-        return []
-    return [
-        jedi_utils.lsp_symbol_information(name)
-        for name in itertools.islice(names, 20)
-    ]
+#     async def register(self, method: str, options: List[Option]) -> None:
+#         response = await self.server.register_capability_async(
+#             RegistrationParams(
+#                 [
+#                     Registration(
+#                         str(uuid.uuid4()), method, self.get_options(options)
+#                     )
+#                 ]
+#             )
+#         )
+#         if response is not None:
+#             self.server.show_message(
+#                 f"jedi-language-server: error during {method} registration",
+#                 MessageType.Error,
+#             )
+
+# @SERVER.feature(INITIALIZED)
+# async def lsp_initialize(server: LanguageServer, params: InitializeParams):
+#     """Initialize language server"""
+#     config = ServerConfig(server, params.initializationOptions)
+#     await config.register(
+#         COMPLETION,
+#         [
+#             Option(
+#                 name_user="completion_triggerCharacters",
+#                 name_system="triggerCharacters",
+#                 default=[".", "'", '"'],
+#             )
+#         ],
+#     )
+#     server.show_message("jedi-language-server: registration complete")

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -43,13 +43,7 @@ from pygls.types import (
 )
 from pygls.workspace import Document
 
-from .jedi_utils import (
-    get_jedi_line_column,
-    get_jedi_project,
-    get_jedi_script,
-    get_location_from_name,
-    get_symbol_information_from_name,
-)
+from . import jedi_utils
 from .type_map import get_lsp_completion_type
 
 SERVER = LanguageServer()
@@ -136,8 +130,8 @@ def _char_before_cursor(
 @SERVER.feature(COMPLETION)
 def lsp_completion(server: LanguageServer, params: CompletionParams):
     """Returns completion items"""
-    jedi_script = get_jedi_script(server.workspace, params.textDocument)
-    jedi_lines = get_jedi_line_column(params.position)
+    jedi_script = jedi_utils.get_script(server.workspace, params.textDocument)
+    jedi_lines = jedi_utils.get_line_column(params.position)
     completions = jedi_script.complete(**jedi_lines)
     char = _char_before_cursor(
         document=server.workspace.get_document(params.textDocument.uri),
@@ -163,12 +157,12 @@ def lsp_definition(
     server: LanguageServer, params: TextDocumentPositionParams
 ) -> List[Location]:
     """Support Goto Definition"""
-    jedi_script = get_jedi_script(server.workspace, params.textDocument)
-    jedi_lines = get_jedi_line_column(params.position)
+    jedi_script = jedi_utils.get_script(server.workspace, params.textDocument)
+    jedi_lines = jedi_utils.get_line_column(params.position)
     names = jedi_script.goto(
         follow_imports=True, follow_builtin_imports=True, **jedi_lines,
     )
-    return [get_location_from_name(name) for name in names]
+    return [jedi_utils.get_lsp_location(name) for name in names]
 
 
 @SERVER.feature(HOVER)
@@ -176,8 +170,8 @@ def lsp_hover(
     server: LanguageServer, params: TextDocumentPositionParams
 ) -> Hover:
     """Support Hover"""
-    jedi_script = get_jedi_script(server.workspace, params.textDocument)
-    jedi_lines = get_jedi_line_column(params.position)
+    jedi_script = jedi_utils.get_script(server.workspace, params.textDocument)
+    jedi_lines = jedi_utils.get_line_column(params.position)
     try:
         _names = jedi_script.help(**jedi_lines)
     except Exception:  # pylint: disable=broad-except
@@ -192,13 +186,13 @@ def lsp_references(
     server: LanguageServer, params: TextDocumentPositionParams
 ) -> List[Location]:
     """Obtain all references to document"""
-    jedi_script = get_jedi_script(server.workspace, params.textDocument)
-    jedi_lines = get_jedi_line_column(params.position)
+    jedi_script = jedi_utils.get_script(server.workspace, params.textDocument)
+    jedi_lines = jedi_utils.get_line_column(params.position)
     try:
         names = jedi_script.get_references(**jedi_lines)
     except Exception:  # pylint: disable=broad-except
         return []
-    return [get_location_from_name(name) for name in names]
+    return [jedi_utils.get_lsp_location(name) for name in names]
 
 
 @SERVER.feature(RENAME)
@@ -206,13 +200,13 @@ def lsp_rename(
     server: LanguageServer, params: RenameParams
 ) -> Optional[WorkspaceEdit]:
     """Rename a symbol across a workspace"""
-    jedi_script = get_jedi_script(server.workspace, params.textDocument)
-    jedi_lines = get_jedi_line_column(params.position)
+    jedi_script = jedi_utils.get_script(server.workspace, params.textDocument)
+    jedi_lines = jedi_utils.get_line_column(params.position)
     try:
         names = jedi_script.get_references(**jedi_lines)
     except Exception:  # pylint: disable=broad-except
         return None
-    locations = [get_location_from_name(name) for name in names]
+    locations = [jedi_utils.get_lsp_location(name) for name in names]
     if not locations:
         return None
     changes = {}  # type: Dict[str, List[TextEdit]]
@@ -230,12 +224,12 @@ def lsp_document_symbol(
     server: LanguageServer, params: DocumentSymbolParams
 ) -> List[SymbolInformation]:
     """Document Python document symbols"""
-    jedi_script = get_jedi_script(server.workspace, params.textDocument)
+    jedi_script = jedi_utils.get_script(server.workspace, params.textDocument)
     try:
         names = jedi_script.get_names()
     except Exception:  # pylint: disable=broad-except
         return []
-    return [get_symbol_information_from_name(name) for name in names]
+    return [jedi_utils.get_lsp_symbol_information(name) for name in names]
 
 
 @SERVER.feature(WORKSPACE_SYMBOL)
@@ -243,7 +237,7 @@ def lsp_workspace_symbol(
     server: LanguageServer, params: WorkspaceSymbolParams
 ) -> List[SymbolInformation]:
     """Document Python workspace symbols"""
-    jedi_project = get_jedi_project(server.workspace)
+    jedi_project = jedi_utils.get_project(server.workspace)
     if params.query.strip() == "":
         return []
     try:
@@ -251,6 +245,6 @@ def lsp_workspace_symbol(
     except Exception:  # pylint: disable=broad-except
         return []
     return [
-        get_symbol_information_from_name(name)
+        jedi_utils.get_lsp_symbol_information(name)
         for name in itertools.islice(names, 20)
     ]

--- a/jedi_language_server/type_map.py
+++ b/jedi_language_server/type_map.py
@@ -78,11 +78,11 @@ _JEDI_SYMBOL_TYPE_MAP = {
 }
 
 
-def get_lsp_completion_type(jedi_type: str) -> int:
+def get_lsp_completion_type(jedi_type: str) -> CompletionItemKind:
     """Get type map. Always return a value."""
     return _JEDI_COMPLETION_TYPE_MAP.get(jedi_type, CompletionItemKind.Text)
 
 
-def get_lsp_symbol_type(jedi_type: str) -> int:
+def get_lsp_symbol_type(jedi_type: str) -> SymbolKind:
     """Get type map. Always return a value."""
     return _JEDI_SYMBOL_TYPE_MAP.get(jedi_type, SymbolKind.Namespace)

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,3 @@
 
 [mypy-jedi.*]
 ignore_missing_imports = True
-
-[mypy-pygls.*]
-ignore_missing_imports = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -124,7 +124,7 @@ description = "File identification library for Python"
 name = "identify"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "1.4.14"
+version = "1.4.15"
 
 [package.extras]
 license = ["editdistance"]
@@ -338,10 +338,10 @@ description = "a pythonic generic language server (pronounced like \"pie glass\"
 name = "pygls"
 optional = false
 python-versions = "*"
-version = "0.8.1"
+version = "0.9.0"
 
 [package.extras]
-dev = ["bandit (1.6.0)", "flake8 (3.7.7)"]
+dev = ["bandit (1.6.0)", "flake8 (3.7.7)", "mypy (0.761)"]
 docs = ["sphinx (2.0.1)", "sphinx-rtd-theme (0.4.3)"]
 test = ["mock (3.0.5)", "pytest (4.5.0)", "pytest-asyncio (0.10.0)"]
 
@@ -605,8 +605,8 @@ filelock = [
     {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
 ]
 identify = [
-    {file = "identify-1.4.14-py2.py3-none-any.whl", hash = "sha256:2bb8760d97d8df4408f4e805883dad26a2d076f04be92a10a3e43f09c6060742"},
-    {file = "identify-1.4.14.tar.gz", hash = "sha256:faffea0fd8ec86bb146ac538ac350ed0c73908326426d387eded0bcc9d077522"},
+    {file = "identify-1.4.15-py2.py3-none-any.whl", hash = "sha256:88ed90632023e52a6495749c6732e61e08ec9f4f04e95484a5c37b9caf40283c"},
+    {file = "identify-1.4.15.tar.gz", hash = "sha256:23c18d97bb50e05be1a54917ee45cc61d57cb96aedc06aabb2b02331edf0dbf0"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},
@@ -700,8 +700,8 @@ py = [
     {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
 ]
 pygls = [
-    {file = "pygls-0.8.1-py3-none-any.whl", hash = "sha256:3ee878a828b7bc0873a2ea44208d6846a91aa7dbbbdc052e7fe8cc689f6644fa"},
-    {file = "pygls-0.8.1.tar.gz", hash = "sha256:780fd0c5ae95ad02ecaf70b071e43ff8ced8384b7d6bed19311a7b431d26fb88"},
+    {file = "pygls-0.9.0-py3-none-any.whl", hash = "sha256:8fab2fa1286ce23b9f33c5779950ce6293122f564d8cc4c669907f39953f5c89"},
+    {file = "pygls-0.9.0.tar.gz", hash = "sha256:0be0dce93745cba445b7a2568910ca7e45a3865347f01860eff9ed3e37e64e7b"},
 ]
 pylint = [
     {file = "pylint-2.4.4-py3-none-any.whl", hash = "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ include_trailing_comma = true
 
 [tool.poetry]
 name = "jedi-language-server"
-version = "0.6.1"
+version = "0.7.0"
 description = "A language server for Jedi!"
 authors = ["Sam Roeca <samuel.roeca@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
### Added

- Support user-configuration rooted at `jedi`. Only 1 option for now: `jedi.completion.triggerCharacters`. Same defaults as version `0.6.1`.
- Message flashes after initialization.

### Changed

- `pygls` types now checked. Version `0.9.0` provides type-hint checking support.