### PR TITLE
Make multiline extract_function possible

### DIFF
--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -202,6 +202,18 @@ def line_column(position: Position) -> Dict[str, int]:
     """
     return dict(line=position.line + 1, column=position.character)
 
+def line_column_range(pygls_range: Range) -> Dict[str, int]:
+    """Translate pygls range to Jedi's line / column / until_line / until_column
+
+    Returns a dictionary because this return result should be unpacked as a
+    function argument to Jedi's functions.
+
+    Jedi is 1-indexed for lines and 0-indexed for columns. LSP is 0-indexed for
+    lines and 0-indexed for columns. Therefore, add 1 to LSP's request for the
+    line.
+    """
+    return dict(line=pygls_range.start.line + 1, column=pygls_range.start.character,
+                until_line=pygls_range.end.line, until_column=pygls_range.end.character)
 
 def compare_names(name1: Name, name2: Name) -> bool:
     """Check if one Name is equal to another

--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -213,7 +213,7 @@ def line_column_range(pygls_range: Range) -> Dict[str, int]:
     line.
     """
     return dict(line=pygls_range.start.line + 1, column=pygls_range.start.character,
-                until_line=pygls_range.end.line, until_column=pygls_range.end.character)
+                until_line=pygls_range.end.line + 1, until_column=pygls_range.end.character)
 
 def compare_names(name1: Name, name2: Name) -> bool:
     """Check if one Name is equal to another

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -353,6 +353,7 @@ def code_action(
     jedi_script = jedi_utils.script(server.workspace, params.textDocument.uri)
     code_actions = []
     jedi_lines = jedi_utils.line_column(params.range.start)
+    jedi_lines_extract = jedi_utils.line_column_range(params.range)
 
     try:
         inline_refactoring = jedi_script.inline(**jedi_lines)
@@ -374,7 +375,7 @@ def code_action(
     extract_var = jedi_utils.random_var("var_")
     try:
         extract_variable_refactoring = jedi_script.extract_variable(
-            new_name=extract_var, **jedi_lines
+            new_name=extract_var, **jedi_lines_extract
         )
     except RefactoringError:
         extract_variable_changes = []  # type: ignore
@@ -394,7 +395,7 @@ def code_action(
     extract_func = jedi_utils.random_var("func_")
     try:
         extract_function_refactoring = jedi_script.extract_function(
-            new_name=extract_func, **jedi_lines
+            new_name=extract_func, **jedi_lines_extract
         )
     except RefactoringError:
         extract_function_changes = []  # type: ignore


### PR DESCRIPTION
Not sure why jedi's `extract_variable` also can take `until_line` and `until_column`? However, everything seems to work.

See issue (in wrong repo): https://github.com/pappasam/coc-jedi/issues/6

For future work: it would be nice to able to pass a function/variable name beforehand, if possible. 