### PR TITLE
[WIP] Jedi project sys.path manipulation

### DIFF
--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -5,6 +5,7 @@ Translates pygls types back and forth with Jedi
 
 import random
 import string  # pylint: disable=deprecated-module
+import sys
 from inspect import Parameter
 from typing import Dict, List, Optional, Tuple
 
@@ -55,6 +56,12 @@ def script(workspace: Workspace, uri: str) -> Script:
 
 def project(workspace: Workspace) -> Project:
     """Simplifies getting jedi project."""
+
+    extra_paths = getattr(workspace, "extra_paths", [])
+    for path in extra_paths:
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
     return Project(
         path=workspace.root_path,
         smart_sys_path=True,

--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -64,6 +64,7 @@ def project(workspace: Workspace) -> Project:
 
     return Project(
         path=workspace.root_path,
+        sys_path=sys.path,
         smart_sys_path=True,
         load_unsafe_extensions=False,
     )

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -82,7 +82,12 @@ class JediLanguageServerProtocol(LanguageServerProtocol):
                 server.feature(TEXT_DOCUMENT_DID_CHANGE)(did_change)
             if ip.initializationOptions_diagnostics_didSave:
                 server.feature(TEXT_DOCUMENT_DID_SAVE)(did_save)
-        return super().bf_initialize(params)
+        res = super().bf_initialize(params)
+
+        extraPaths = getattr(params.initializationOptions, 'extraPaths', [])
+        self.workspace.extra_paths = extraPaths
+
+        return res
 
 
 class JediLanguageServer(LanguageServer):


### PR DESCRIPTION
At work I use an upstream project which is structured in a way where to get Jedi to autocomplete, etc. we need to modify the sys.path (I can explain more if required, but think a root project, with a vendors directory, almost). Under coc-python I use the python.autocomplete.extraPaths feature to get autocomplete, etc. working.

This is an *extremely* early implementation (no tests, total hack) to find out if you're happy with the concept of adding something like this to jedi-language-server. If yes I'll find a way to tidy it up, get some tests in, etc.

From a coc-jedi perspective adding `jedi.extraPaths: ['path1/', 'path2/']` to the project's coc-settings.json with this PR gets me working.