### PR TITLE
Implement completionItem/resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ jedi-language-server aims to support all of Jedi's capabilities and expose them 
 
 ### Language Features
 
+- [completionItem/resolve](https://microsoft.github.io/language-server-protocol/specification#completionItem_resolve)
 - [textDocument/codeAction](https://microsoft.github.io/language-server-protocol/specification#textDocument_codeAction) (refactor.inline, refactor.extract)
 - [textDocument/completion](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion)
 - [textDocument/definition](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_definition)
@@ -91,7 +92,8 @@ If you are configuring manually, jedi-language-server supports the following [in
       "autoImportModules": []
     },
     "completion": {
-      "disableSnippets": false
+      "disableSnippets": false,
+      "resolveEagerly": false
     },
     "diagnostics": {
       "enable": true,

--- a/jedi_language_server/initialize_params_parser.py
+++ b/jedi_language_server/initialize_params_parser.py
@@ -137,6 +137,17 @@ class InitializeParamsParser:
         return bool(rgetattr(self._initialize_params, path, default))
 
     @cached_property
+    def initializationOptions_completion_resolveEagerly(self):
+        _path = (
+            "initializationOptions",
+            "completion",
+            "resolveEagerly",
+        )
+        path = ".".join(_path)
+        default = False
+        return bool(rgetattr(self._initialize_params, path, default))
+
+    @cached_property
     def initializationOptions_diagnostics_enable(self) -> bool:
         _path = (
             "initializationOptions",

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -7,7 +7,7 @@ Official language server spec:
 """
 
 import itertools
-from typing import List, NamedTuple, Optional, Union
+from typing import List, Optional, Union
 
 from jedi import Project
 from jedi.api.refactoring import RefactoringError
@@ -120,12 +120,29 @@ SERVER = JediLanguageServer(protocol_cls=JediLanguageServerProtocol)
 
 @SERVER.feature(COMPLETION_ITEM_RESOLVE)
 def completion_item_resolve(
-    server: JediLanguageServer, item_params: NamedTuple
+    server: JediLanguageServer, params: CompletionItem
 ) -> CompletionItem:
     """Resolves documentation and detail of given completion item."""
     markup_kind = choose_markup(server)
-    params = item_params._asdict()
-    item = CompletionItem(**params)
+    # note: params is not a CompletionItem
+    # but a namedtuple complying with CompletionItem protocol
+    item = CompletionItem(
+        label=params.label,
+        kind=params.kind,
+        detail=params.detail,
+        documentation=params.documentation,
+        deprecated=params.deprecated,
+        preselect=params.preselect,
+        sort_text=params.sortText,
+        filter_text=params.filterText,
+        insert_text=params.insertText,
+        insert_text_format=params.insertTextFormat,
+        text_edit=params.textEdit,
+        additional_text_edits=params.additionalTextEdits,
+        commit_characters=params.commitCharacters,
+        command=params.command,
+        data=params.data,
+    )
     return jedi_utils.lsp_completion_item_resolve(
         item, markup_kind=markup_kind
     )

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -14,6 +14,7 @@ from jedi.api.refactoring import RefactoringError
 from pygls.features import (
     CODE_ACTION,
     COMPLETION,
+    COMPLETION_ITEM_RESOLVE,
     DEFINITION,
     DOCUMENT_HIGHLIGHT,
     DOCUMENT_SYMBOL,
@@ -32,6 +33,7 @@ from pygls.types import (
     CodeAction,
     CodeActionKind,
     CodeActionParams,
+    CompletionItem,
     CompletionList,
     CompletionParams,
     DidChangeTextDocumentParams,
@@ -45,6 +47,7 @@ from pygls.types import (
     InitializeResult,
     Location,
     MarkupContent,
+    MarkupKind,
     RenameParams,
     SymbolInformation,
     TextDocumentPositionParams,
@@ -115,6 +118,17 @@ SERVER = JediLanguageServer(protocol_cls=JediLanguageServerProtocol)
 # Server capabilities
 
 
+@SERVER.feature(COMPLETION_ITEM_RESOLVE)
+def completion_item_resolve(
+    server: JediLanguageServer, item: CompletionItem
+) -> CompletionItem:
+    """Resolves documentation and detail of given completion item."""
+    markup_kind = choose_markup(server)
+    return jedi_utils.lsp_completion_item_resolve(
+        item, markup_kind=markup_kind
+    )
+
+
 @SERVER.feature(COMPLETION, trigger_characters=[".", "'", '"'])
 def completion(
     server: JediLanguageServer, params: CompletionParams
@@ -124,23 +138,16 @@ def completion(
     jedi_script = jedi_utils.script(server.project, document)
     jedi_lines = jedi_utils.line_column(jedi_script, params.position)
     completions_jedi = jedi_script.complete(**jedi_lines)
-    markup_preferred = (
-        server.initialize_params.initializationOptions_markupKindPreferred
-    )
-    markup_supported = (
-        server.initialize_params.capabilities_textDocument_completion_completionItem_documentationFormat
-    )
-    markup_kind = (
-        markup_preferred
-        if markup_preferred in markup_supported
-        else markup_supported[0]
-    )
     snippet_support = (
         server.initialize_params.capabilities_textDocument_completion_completionItem_snippetSupport
     )
     snippet_disable = (
         server.initialize_params.initializationOptions_completion_disableSnippets
     )
+    resolve_eagerly = (
+        server.initialize_params.initializationOptions_completion_resolveEagerly
+    )
+    markup_kind = choose_markup(server)
     is_import_context = jedi_utils.is_import(
         script_=jedi_script,
         line=jedi_lines["line"],
@@ -153,11 +160,13 @@ def completion(
         document=server.workspace.get_document(params.textDocument.uri),
         position=params.position,
     )
+    jedi_utils.clear_completions_cache()
     completion_items = [
         jedi_utils.lsp_completion_item(
-            name=completion,
+            completion=completion,
             char_before_cursor=char_before_cursor,
             enable_snippets=enable_snippets,
+            resolve_eagerly=resolve_eagerly,
             markup_kind=markup_kind,
         )
         for completion in completions_jedi
@@ -255,17 +264,7 @@ def hover(
         docstring = name.docstring()
         if not docstring:
             continue
-        markup_preferred = (
-            server.initialize_params.initializationOptions_markupKindPreferred
-        )
-        markup_supported = (
-            server.initialize_params.capabilities_textDocument_hover_contentFormat
-        )
-        markup_kind = (
-            markup_preferred
-            if markup_preferred in markup_supported
-            else markup_supported[0]
-        )
+        markup_kind = choose_markup(server)
         contents = MarkupContent(kind=markup_kind, value=docstring)
         document = server.workspace.get_document(params.textDocument.uri)
         _range = pygls_utils.current_word_range(document, params.position)
@@ -498,3 +497,18 @@ def did_change(
 def did_open(server: JediLanguageServer, params: DidOpenTextDocumentParams):
     """Actions run on textDocument/didOpen."""
     _publish_diagnostics(server, params.textDocument.uri)
+
+
+def choose_markup(server: JediLanguageServer) -> MarkupKind:
+    """Returns the preferred or first of supported markup kinds."""
+    markup_preferred = (
+        server.initialize_params.initializationOptions_markupKindPreferred
+    )
+    markup_supported = (
+        server.initialize_params.capabilities_textDocument_completion_completionItem_documentationFormat
+    )
+    return (
+        markup_preferred
+        if markup_preferred in markup_supported
+        else markup_supported[0]
+    )

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -7,7 +7,7 @@ Official language server spec:
 """
 
 import itertools
-from typing import List, Optional, Union
+from typing import List, NamedTuple, Optional, Union
 
 from jedi import Project
 from jedi.api.refactoring import RefactoringError
@@ -120,10 +120,12 @@ SERVER = JediLanguageServer(protocol_cls=JediLanguageServerProtocol)
 
 @SERVER.feature(COMPLETION_ITEM_RESOLVE)
 def completion_item_resolve(
-    server: JediLanguageServer, item: CompletionItem
+    server: JediLanguageServer, item_params: NamedTuple
 ) -> CompletionItem:
     """Resolves documentation and detail of given completion item."""
     markup_kind = choose_markup(server)
+    params = item_params._asdict()
+    item = CompletionItem(**params)
     return jedi_utils.lsp_completion_item_resolve(
         item, markup_kind=markup_kind
     )


### PR DESCRIPTION
- [x] Implemented `completionItem/resolve`; the Jedi completion data are held until the next `textDocument/completion` arrives
- [x] Added `completion.resolveEagerly` option to allow users to opt out of the change (in anticipation for their editor to support `completionItem/resolve` if it does not already)
- [x] Tested

Following up on https://github.com/pappasam/jedi-language-server/issues/45#issuecomment-770209093.