### PR TITLE
Fix workspace symbol retrieval error due to updates in Jedi 0.18.0

### DIFF
--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -373,8 +373,8 @@ def workspace_symbol(
         jedi_utils.lsp_symbol_information(name)
         for name in names
         if name.module_path
-        and name.module_path.startswith(workspace_root)
-        and not _ignore_folder(name.module_path)
+        and str(name.module_path).startswith(workspace_root)
+        and not _ignore_folder(str(name.module_path))
     )
     symbols = list(itertools.islice(_symbols, 20))
     return symbols if symbols else None


### PR DESCRIPTION
[Jedi 0.18.0](https://github.com/davidhalter/jedi/releases/tag/v0.18.0) uses `pathlib.Path` in place of `str` in most places, but these lines for handling workspace symbols are not updated accordingly:

https://github.com/pappasam/jedi-language-server/blob/7aeacbef69a64b0019425f60bdfb4cfee05b4315/jedi_language_server/server.py#L372-L377

This PR fixes this.

Thanks for this awesome lightweight language server BTW :)
