### PR TITLE
Fix the docstrings conversion

### DIFF
--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -393,11 +393,15 @@ def convert_docstring(docstring: str, markup_kind: MarkupKind) -> str:
     handling in case docstring_to_markdown.convert produces unexpected
     behavior.
     """
-    if markup_kind == markup_kind.Markdown:
+    if markup_kind == MarkupKind.Markdown:
         try:
             return docstring_to_markdown.convert(docstring)
         except docstring_to_markdown.UnknownFormatError:
-            pass
+            return (
+                "```\n" + str(docstring) + "\n```\n"
+                if docstring
+                else docstring
+            )
         except Exception as error:  # pylint: disable=broad-except
             return (
                 docstring


### PR DESCRIPTION
Fixes:

```
    if markup_kind == markup_kind.Markdown:
AttributeError: 'str' object has no attribute 'Markdown'
```

and makes sure that pre-formatted text will be shown as such (https://github.com/pappasam/jedi-language-server/issues/68). An alternative would be to change the markup kind to `MarkupKind.PlainText` if the `docstring_to_markdown` cannot parse instead but this way was faster to patch without rewriting logic.
