### PR TITLE
Fix handling of completionItem/resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Unreleased
 
 - Fix handling of `completionItem/resolve` when not all fields are present on the `CompletionItem`.
+- Fix handling of eager resolution of completions.
 
 ## 0.25.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Fix handling of `completionItem/resolve` when not all fields are present on the `CompletionItem`.
+
 ## 0.25.4
 
 ### Fixed

--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -357,12 +357,12 @@ def lsp_completion_item(
         insert_text=name_clean,
         insert_text_format=InsertTextFormat.PlainText,
     )
+
+    _MOST_RECENT_COMPLETIONS[completion_name] = completion
     if resolve_eagerly:
         completion_item = lsp_completion_item_resolve(
             completion_item, markup_kind=markup_kind
         )
-    else:
-        _MOST_RECENT_COMPLETIONS[completion_name] = completion
 
     if not enable_snippets:
         return completion_item

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -131,7 +131,7 @@ def completion_item_resolve(
     item = CompletionItem(
         label=params.label,
         kind=getattr(params, "kind", None),
-        detail=getattr(params, "details", None),
+        detail=getattr(params, "detail", None),
         documentation=getattr(params, "documentation", None),
         deprecated=getattr(params, "deprecated", None),
         preselect=getattr(params, "preselect", None),

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -7,7 +7,7 @@ Official language server spec:
 """
 
 import itertools
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 from jedi import Project
 from jedi.api.refactoring import RefactoringError
@@ -122,7 +122,7 @@ SERVER = JediLanguageServer(protocol_cls=JediLanguageServerProtocol)
 
 @SERVER.feature(COMPLETION_ITEM_RESOLVE)
 def completion_item_resolve(
-    server: JediLanguageServer, params: CompletionItem
+    server: JediLanguageServer, params: Any
 ) -> CompletionItem:
     """Resolves documentation and detail of given completion item."""
     markup_kind = _choose_markup(server)
@@ -130,20 +130,20 @@ def completion_item_resolve(
     # but a namedtuple complying with CompletionItem protocol
     item = CompletionItem(
         label=params.label,
-        kind=params.kind,
-        detail=params.detail,
-        documentation=params.documentation,
-        deprecated=params.deprecated,
-        preselect=params.preselect,
-        sort_text=params.sortText,
-        filter_text=params.filterText,
-        insert_text=params.insertText,
-        insert_text_format=params.insertTextFormat,
-        text_edit=params.textEdit,
-        additional_text_edits=params.additionalTextEdits,
-        commit_characters=params.commitCharacters,
-        command=params.command,
-        data=params.data,
+        kind=getattr(params, "kind", None),
+        detail=getattr(params, "details", None),
+        documentation=getattr(params, "documentation", None),
+        deprecated=getattr(params, "deprecated", None),
+        preselect=getattr(params, "preselect", None),
+        sort_text=getattr(params, "sortText", None),
+        filter_text=getattr(params, "filterText", None),
+        insert_text=getattr(params, "insertText", None),
+        insert_text_format=getattr(params, "insertTextFormat", None),
+        text_edit=getattr(params, "textEdit", None),
+        additional_text_edits=getattr(params, "additionalTextEdits", None),
+        commit_characters=getattr(params, "commitCharacters", None),
+        command=getattr(params, "command", None),
+        data=getattr(params, "data", None),
     )
     return jedi_utils.lsp_completion_item_resolve(
         item, markup_kind=markup_kind

--- a/tests/lsp_test_client/session.py
+++ b/tests/lsp_test_client/session.py
@@ -119,6 +119,13 @@ class LspSession(MethodDispatcher):
         fut = self._send_request("textDocument/rename", params=rename_params)
         return fut.result()
 
+    def completion_item_resolve(self, resolve_params):
+        """Sends completion item resolve request to LSP server."""
+        fut = self._send_request(
+            "completionItem/resolve", params=resolve_params
+        )
+        return fut.result()
+
     def _send_request(
         self, name, params=None, handle_response=lambda f: f.done()
     ):

--- a/tests/lsp_tests/test_completion.py
+++ b/tests/lsp_tests/test_completion.py
@@ -48,3 +48,35 @@ def test_lsp_completion() -> None:
             ],
         }
         assert_that(actual, is_(expected))
+
+        actual = ls_session.completion_item_resolve(
+            {
+                "label": "my_function",
+                "kind": 3,
+                "sortText": "z",
+                "filterText": "my_function",
+                "insertText": "my_function()$0",
+                "insertTextFormat": 2,
+            }
+        )
+        expected = {
+            "label": "my_function",
+            "kind": 3,
+            "detail": "def my_function",
+            "documentation": {
+                "kind": "markdown",
+                "value": "```\nmy_function()\n\nSimple test function.\n```\n",
+            },
+            "deprecated": None,
+            "preselect": None,
+            "sortText": "z",
+            "filterText": "my_function",
+            "insertText": "my_function()$0",
+            "insertTextFormat": 2,
+            "textEdit": None,
+            "additionalTextEdits": None,
+            "commitCharacters": None,
+            "command": None,
+            "data": None,
+        }
+        assert_that(actual, is_(expected))

--- a/tests/lsp_tests/test_completion.py
+++ b/tests/lsp_tests/test_completion.py
@@ -1,9 +1,12 @@
 """Tests for document completion requests."""
 
+import copy
+
 from hamcrest import assert_that, is_
 
 from tests import TEST_DATA
 from tests.lsp_test_client import session
+from tests.lsp_test_client.defaults import VSCODE_DEFAULT_INITIALIZE
 from tests.lsp_test_client.utils import as_uri
 
 COMPLETION_TEST_ROOT = TEST_DATA / "completion"
@@ -16,6 +19,7 @@ def test_lsp_completion() -> None:
     """
 
     with session.LspSession() as ls_session:
+        ls_session.initialize()
         uri = as_uri(COMPLETION_TEST_ROOT / "completion_test1.py")
         actual = ls_session.text_document_completion(
             {
@@ -78,5 +82,57 @@ def test_lsp_completion() -> None:
             "commitCharacters": None,
             "command": None,
             "data": None,
+        }
+        assert_that(actual, is_(expected))
+
+
+def test_eager_lsp_completion() -> None:
+    """Test a simple completion request, with eager resolution.
+
+    Test Data: tests/test_data/completion/completion_test1.py
+    """
+
+    with session.LspSession() as ls_session:
+        # Initialize, asking for eager resolution.
+        initialize_params = copy.deepcopy(VSCODE_DEFAULT_INITIALIZE)
+        initialize_params["initializationOptions"] = {
+            "completion": {"resolveEagerly": True}
+        }
+        ls_session.initialize(initialize_params)
+
+        uri = as_uri(COMPLETION_TEST_ROOT / "completion_test1.py")
+        actual = ls_session.text_document_completion(
+            {
+                "textDocument": {"uri": uri},
+                "position": {"line": 8, "character": 2},
+                "context": {"triggerKind": 1},
+            }
+        )
+
+        # pylint: disable=line-too-long
+        expected = {
+            "isIncomplete": False,
+            "items": [
+                {
+                    "label": "my_function",
+                    "kind": 3,
+                    "detail": "def my_function",
+                    "documentation": {
+                        "kind": "markdown",
+                        "value": "```\nmy_function()\n\nSimple test function.\n```\n",
+                    },
+                    "deprecated": False,
+                    "preselect": False,
+                    "sortText": "z",
+                    "filterText": "my_function",
+                    "insertText": "my_function()$0",
+                    "insertTextFormat": 2,
+                    "textEdit": None,
+                    "additionalTextEdits": None,
+                    "commitCharacters": None,
+                    "command": None,
+                    "data": None,
+                }
+            ],
         }
         assert_that(actual, is_(expected))

--- a/tests/lsp_tests/test_rename.py
+++ b/tests/lsp_tests/test_rename.py
@@ -12,6 +12,7 @@ REFACTOR_TEST_ROOT = TEST_DATA / "refactoring"
 def test_lsp_rename_function():
     """Tests single file function rename."""
     with session.LspSession() as ls_session:
+        ls_session.initialize()
         uri = as_uri((REFACTOR_TEST_ROOT / "rename_test1.py"))
         actual = ls_session.text_document_rename(
             {


### PR DESCRIPTION
Not all fields are necessarily present on the completionItem, don't assume that they are.

Previously would see errors like:
```
"rpc">  "jedi-language-server"> "stderr">   "Failed to handle request 3 completionItem/resolve Object(label='NamedTuple', deprecated=False, preselect=False, sortText='z', insertText='NamedTuple(${1:typename})$0', filterText='NamedTuple', kind=7, insertTextFormat=2)\nTraceback (most recent call last):\n  File \"/home/dch/.virtualenvs/foo/lib/python3.8/site-packages/pygls/protocol.py\", line 324, in _handle_request\n    self._execute_request(msg_id, handler, params)\n  File \"/home/dch/.virtualenvs/foo/lib/python3.8/site-packages/pygls/protocol.py\", line 249, in _execute_request\n    self._send_response(msg_id, handler(params))\n  File \"/home/dch/jedi-language-server/jedi_language_server/server.py\", line 134, in completion_item_resolve\n    detail=params.detail,\nAttributeError: 'Object' object has no attribute 'detail'\n"
```

FYI @krassowski 

Not super-happy about typing this as `Any`, but not seeing a clearly better option.