### PR TITLE
Fix renaming a variable at the start of a line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Fix renaming a variable that appears at the start of a line
+
 ## 0.25.4
 
 ### Fixed

--- a/jedi_language_server/text_edit_utils.py
+++ b/jedi_language_server/text_edit_utils.py
@@ -184,7 +184,7 @@ def get_opcode_position_lookup(
     start = 0
     for line, code_line in enumerate(original_lines):
         end = start + len(code_line)
-        key = range(start, end + 1)  # must be 1 greater than last item
+        key = range(start, end)
         line_lookup[key] = LinePosition(start, end, line, code_line)
         start = end
     return line_lookup

--- a/tests/lsp_tests/test_rename.py
+++ b/tests/lsp_tests/test_rename.py
@@ -77,3 +77,38 @@ def test_lsp_rename_function():
             ],
         }
         assert_that(actual, is_(expected))
+
+
+def test_lsp_rename_variable_at_line_start():
+    """Tests renaming a variable that appears at the start of a line."""
+    with session.LspSession() as ls_session:
+        uri = as_uri((REFACTOR_TEST_ROOT / "rename_test2.py"))
+        actual = ls_session.text_document_rename(
+            {
+                "textDocument": {"uri": uri},
+                "position": {"line": 1, "character": 0},
+                "newName": "y",
+            }
+        )
+
+        expected = {
+            "changes": None,
+            "documentChanges": [
+                {
+                    "textDocument": {
+                        "uri": uri,
+                        "version": 0,
+                    },
+                    "edits": [
+                        {
+                            "range": {
+                                "start": {"line": 1, "character": 0},
+                                "end": {"line": 1, "character": 1},
+                            },
+                            "newText": "y",
+                        },
+                    ],
+                }
+            ],
+        }
+        assert_that(actual, is_(expected))

--- a/tests/test_data/refactoring/rename_test2.py
+++ b/tests/test_data/refactoring/rename_test2.py
@@ -1,0 +1,2 @@
+# Variable to be renamed appears at the very start of the line.
+x = 3


### PR DESCRIPTION
Since I was on a roll, I wondered about #63.

Seems like a straightforward out-by-one error where the first character of a line is wrongly considered to be on the previous line (and also on its own line; but we find the previous line first).

However, it's clear that the code that I am fixing was deliberately written that way - at b6abf85676bb1e5eae9ad79f2b050e8dfdd33e39.  Perhaps you'll remember the reason for that, and therefore what this breaks!

Fixes #63.