### PR TITLE
Apply the null removal monkeypatch, fixing many pygls bugs

### DIFF
--- a/jedi_language_server/__init__.py
+++ b/jedi_language_server/__init__.py
@@ -1,1 +1,100 @@
-"""Jedi Language Server."""
+"""Jedi Language Server.
+
+Code in this module is a temporary workaround to address the following issues:
+- <https://github.com/microsoft/vscode-languageserver-node/issues/
+740#issuecomment-773967897>
+- <https://github.com/pappasam/jedi-language-server/issues/60>
+- <https://github.com/openlawlibrary/pygls/issues/145>
+- <https://github.com/microsoft/vscode-languageserver-node/issues/740>
+
+It's temporary, and taken almost in its entirety from:
+
+<https://github.com/karthiknadig/vscode-python/blob/main/pythonFiles/
+runJediLanguageServer.py>
+
+Remove when either version 0.10 or 1.0 is released for pygls.
+"""
+
+import os
+import sys
+
+import pygls.protocol
+
+# pylint: disable=invalid-name
+
+try:
+    unicode  # pylint: disable=used-before-assignment
+except Exception:  # pylint: disable=broad-except
+    unicode = str
+
+
+def is_json_basic_type(obj):
+    """Checks if the object is an int, float, bool, or str."""
+    if isinstance(obj, (int, float, bool, str)):
+        return True
+    return sys.version_info < (3,) and isinstance(obj, unicode)
+
+
+def handle_null_fields(obj, obj_field_name=None):
+    """Removes fields with a 'None' value.
+
+    The LS Client in VS Code expects optional fields that are not needed
+    to be omitted. Unfortunately, pygls uses 'null' in these instances.
+    """
+    if is_json_basic_type(obj):
+        return
+    if isinstance(obj, list):
+        for o in obj:
+            handle_null_fields(o, obj_field_name)
+        return
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            handle_null_fields(v, k)
+
+    important_attribute = lambda x: not x.startswith("_") and not callable(
+        getattr(obj, x)
+    )
+
+    for attr in filter(important_attribute, dir(obj)):
+        member = getattr(obj, attr)
+        if member is None:
+            # This is a special condition to handle
+            # VersionedTextDocumentIdentifier object.
+            # See issues:
+            # https://github.com/pappasam/jedi-language-server/issues/61
+            # https://github.com/openlawlibrary/pygls/issues/146
+            #
+            # The version field should either use `0` or the value received
+            # from `client`. Seems like using `null` or removing this causes VS
+            # Code to ignore code actions.
+            if (
+                attr == "version"
+                and obj_field_name == "textDocument"
+                and "uri" in dir(obj)
+            ):
+                setattr(obj, "version", 0)
+            else:
+                delattr(obj, attr)
+
+        elif is_json_basic_type(member):
+            continue
+
+        else:
+            handle_null_fields(member, attr)
+
+
+def patched_without_none_fields(resp):
+    """Monkeypatch for `JsonRPCResponseMessage.without_none_fields` to remove
+    `None` results."""
+    if resp.error is None:
+        del resp.error
+        if hasattr(resp, "result"):
+            handle_null_fields(resp.result)
+    else:
+        del resp.result
+    return resp
+
+
+pygls.protocol.JsonRPCResponseMessage.without_none_fields = (  # type: ignore
+    patched_without_none_fields
+)

--- a/tests/lsp_tests/test_completion.py
+++ b/tests/lsp_tests/test_completion.py
@@ -35,19 +35,12 @@ def test_lsp_completion() -> None:
                 {
                     "label": "my_function",
                     "kind": 3,
-                    "detail": None,
-                    "documentation": None,
                     "deprecated": False,
                     "preselect": False,
                     "sortText": "z",
                     "filterText": "my_function",
                     "insertText": "my_function()$0",
                     "insertTextFormat": 2,
-                    "textEdit": None,
-                    "additionalTextEdits": None,
-                    "commitCharacters": None,
-                    "command": None,
-                    "data": None,
                 }
             ],
         }
@@ -71,17 +64,10 @@ def test_lsp_completion() -> None:
                 "kind": "markdown",
                 "value": "```\nmy_function()\n\nSimple test function.\n```\n",
             },
-            "deprecated": None,
-            "preselect": None,
             "sortText": "z",
             "filterText": "my_function",
             "insertText": "my_function()$0",
             "insertTextFormat": 2,
-            "textEdit": None,
-            "additionalTextEdits": None,
-            "commitCharacters": None,
-            "command": None,
-            "data": None,
         }
         assert_that(actual, is_(expected))
 
@@ -127,11 +113,6 @@ def test_eager_lsp_completion() -> None:
                     "filterText": "my_function",
                     "insertText": "my_function()$0",
                     "insertTextFormat": 2,
-                    "textEdit": None,
-                    "additionalTextEdits": None,
-                    "commitCharacters": None,
-                    "command": None,
-                    "data": None,
                 }
             ],
         }

--- a/tests/lsp_tests/test_rename.py
+++ b/tests/lsp_tests/test_rename.py
@@ -23,7 +23,6 @@ def test_lsp_rename_function():
         )
 
         expected = {
-            "changes": None,
             "documentChanges": [
                 {
                     "textDocument": {
@@ -94,7 +93,6 @@ def test_lsp_rename_variable_at_line_start():
         )
 
         expected = {
-            "changes": None,
             "documentChanges": [
                 {
                     "textDocument": {
@@ -134,7 +132,6 @@ def test_lsp_rename_last_line():
         )
 
         expected = {
-            "changes": None,
             "documentChanges": [
                 {
                     "textDocument": {


### PR DESCRIPTION
This applies the monkeypatch written by @karthiknadig directly to jedi-language-server. Since it's unclear how long pygls is going to take getting its pydantic release out, I figure this is a pretty non-invasive way of fixing null issues for users of nvim-lsp, etc.

@karthiknadig I'm curious to get your thoughts on whether you think this could cause problems for VSCode? It'll probably override your monkeypatch code. I've kept your python 2 backwards compatibility in the script just in case. Additionally, I've kept the check for textDocument version number so I know how to handle other special cases if they arise.

Relates to <https://github.com/openlawlibrary/pygls/issues/145> for every edge case that users haven't taken the time to open an issue about on this repo yet.