### PR TITLE
provide accurate version in VersionedTextDocumentIdentifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Provide correct version information on `TextDocumentEdit`.
+
 ## 0.27.1
 
 ### Fixed

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -403,7 +403,9 @@ def rename(
         refactoring = jedi_script.rename(new_name=params.newName, **jedi_lines)
     except RefactoringError:
         return None
-    changes = text_edit_utils.lsp_document_changes(refactoring)
+    changes = text_edit_utils.lsp_document_changes(
+        server.workspace, refactoring
+    )
     return WorkspaceEdit(document_changes=changes) if changes else None  # type: ignore
 
 
@@ -439,7 +441,7 @@ def code_action(
         inline_changes = []  # type: ignore
     else:
         inline_changes = text_edit_utils.lsp_document_changes(
-            inline_refactoring
+            server.workspace, inline_refactoring
         )
     if inline_changes:
         code_actions.append(
@@ -461,7 +463,7 @@ def code_action(
         extract_variable_changes = []  # type: ignore
     else:
         extract_variable_changes = text_edit_utils.lsp_document_changes(
-            extract_variable_refactoring
+            server.workspace, extract_variable_refactoring
         )
     if extract_variable_changes:
         code_actions.append(
@@ -483,7 +485,7 @@ def code_action(
         extract_function_changes = []  # type: ignore
     else:
         extract_function_changes = text_edit_utils.lsp_document_changes(
-            extract_function_refactoring
+            server.workspace, extract_function_refactoring
         )
     if extract_function_changes:
         code_actions.append(


### PR DESCRIPTION
The neovim LSP client checks the version number on a text edit, and refuses to apply it if it decides that the edit is for a too-old version of the document - [here](https://github.com/neovim/neovim/blob/f34eeba2d85b4382d7504e1f3e12a7afb0788c1d/runtime/lua/vim/lsp/util.lua#L219-L221).

Therefore always providing version zero does not go well.

I've plumbed the pygls `Workspace` through to allow retrieving document versions, feels a little heavy-handed but was the simplest thing that came to mind.

