### PR TITLE
TextEdit tidying

### DIFF
--- a/tests/lsp_tests/test_refactoring.py
+++ b/tests/lsp_tests/test_refactoring.py
@@ -114,6 +114,42 @@ def test_lsp_rename_variable_at_line_start():
         assert_that(actual, is_(expected))
 
 
+def test_lsp_rename_inserts_at_line_start():
+    """Tests renaming a variable by inserting text at the start of a line."""
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        uri = as_uri((REFACTOR_TEST_ROOT / "rename_test2.py"))
+        actual = ls_session.text_document_rename(
+            {
+                "textDocument": {"uri": uri},
+                "position": {"line": 1, "character": 0},
+                # old name is "x", so we will insert "a"
+                "newName": "ax",
+            }
+        )
+
+        expected = {
+            "documentChanges": [
+                {
+                    "textDocument": {
+                        "uri": uri,
+                        "version": 0,
+                    },
+                    "edits": [
+                        {
+                            "range": {
+                                "start": {"line": 1, "character": 0},
+                                "end": {"line": 1, "character": 0},
+                            },
+                            "newText": "a",
+                        },
+                    ],
+                }
+            ],
+        }
+        assert_that(actual, is_(expected))
+
+
 def test_lsp_rename_last_line():
     """Tests whether rename works for end of file edge case.
 


### PR DESCRIPTION
I saw the recent bugfix relating to TextEdit, but I think perhaps this is still not quite right.

As I understand it, the real cause of the issue is that opcodes can and do give index values that are out of the range of the input string, eg per the [example](https://docs.python.org/3/library/difflib.html#difflib.SequenceMatcher.get_opcodes) in the documentation:

```python
>>> a = "qabxcd"
>>> b = "abycdf"
>>> s = SequenceMatcher(None, a, b)
>>> for tag, i1, i2, j1, j2 in s.get_opcodes():
...     print('{:7}   a[{}:{}] --> b[{}:{}] {!r:>8} --> {!r}'.format(
...         tag, i1, i2, j1, j2, a[i1:i2], b[j1:j2]))
delete    a[0:1] --> b[0:0]      'q' --> ''
equal     a[1:3] --> b[0:2]     'ab' --> 'ab'
replace   a[3:4] --> b[2:3]      'x' --> 'y'
equal     a[4:6] --> b[3:5]     'cd' --> 'cd'
insert    a[6:6] --> b[5:6]       '' --> 'f'
```
Note edits at `a[4:6]` and `a[6:6]` on a six-character string.  These make sense as ranges, but not when the individual indexes are interpreted standalone.  However, adding padding to handle that one edge case does seems a pretty pragmatic way to handle this.

So I have:
- updated the recent fix so that it doesn't pad at the start, that's surely not needed (no opcode will refer to `old[-1:n]`), and updated the commenting accordingly
- reverted the less recent fix that moved `opcode.old_end` -> `opcode.old_end - 1`.  This is made unnecessary by the padding, and indeed it seems like a bad idea when in the middle of a file (if you're unlucky, you could end up finding the line before the one you wanted).
- while I was here, I also used the pygls `Document` to get the old code, rather than the private jedi method.