### PR TITLE
Add additional information to hover text

### DIFF
--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -420,22 +420,26 @@ def hover_text(names: List[Name], markup_kind: MarkupKind) -> Optional[str]:
     name_str = name.name
     full_name = name.full_name
     description = name.description
-    docstring = name.docstring(raw=True, fast=True)
-    type_hint = name.get_type_hint()
-
+    docstring = name.docstring()
+    try:
+        type_hint = name.get_type_hint()
+    except NotImplementedError:
+        # jedi randomly raises NotImplemented error when inferring some types
+        # one example from jls tests: test_hover.test_hover_on_method
+        type_hint = ""
     result: List[str] = []
     if name:
-        result.append(f"# {name_str}")
+        result.append(f"**Name:** {name_str}")
         result.append("")
     if docstring:
         result.append(convert_docstring(docstring, markup_kind))
         result.append("")
     if description:
-        result.append(f"**Desc:** {description}")
+        result.append(f"*Desc:* {description}")
     if type_hint:
-        result.append(f"**Type:** {type_hint}")
+        result.append(f"*Type:* {type_hint}")
     if full_name:
-        result.append(f"**Path:** {full_name}")
+        result.append(f"*Path:* {full_name}")
     if not result:
         return None
     return "\n".join(result).strip()

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -310,16 +310,15 @@ def hover(
     jedi_script = jedi_utils.script(server.project, document)
     jedi_lines = jedi_utils.line_column(jedi_script, params.position)
     markup_kind = _choose_markup(server)
-    for name in jedi_script.help(**jedi_lines):
-        docstring = name.docstring()
-        if not docstring:
-            continue
-        docstring_clean = jedi_utils.convert_docstring(docstring, markup_kind)
-        contents = MarkupContent(kind=markup_kind, value=docstring_clean)
-        document = server.workspace.get_document(params.text_document.uri)
-        _range = pygls_utils.current_word_range(document, params.position)
-        return Hover(contents=contents, range=_range)
-    return None
+    hover_text = jedi_utils.hover_text(
+        jedi_script.help(**jedi_lines), markup_kind
+    )
+    if not hover_text:
+        return None
+    contents = MarkupContent(kind=markup_kind, value=hover_text)
+    document = server.workspace.get_document(params.text_document.uri)
+    _range = pygls_utils.current_word_range(document, params.position)
+    return Hover(contents=contents, range=_range)
 
 
 @SERVER.feature(REFERENCES)

--- a/tests/lsp_tests/test_completion.py
+++ b/tests/lsp_tests/test_completion.py
@@ -60,7 +60,7 @@ def test_lsp_completion() -> None:
             "detail": "def my_function",
             "documentation": {
                 "kind": "markdown",
-                "value": "```\nmy_function()\n\nSimple test function.\n```\n",
+                "value": "my_function()\n\nSimple test function.",
             },
             "sortText": "z",
             "filterText": "my_function",
@@ -103,7 +103,7 @@ def test_eager_lsp_completion() -> None:
                     "detail": "def my_function",
                     "documentation": {
                         "kind": "markdown",
-                        "value": "```\nmy_function()\n\nSimple test function.\n```\n",
+                        "value": "my_function()\n\nSimple test function.",
                     },
                     "sortText": "z",
                     "filterText": "my_function",
@@ -149,7 +149,7 @@ def test_lsp_completion_class_method() -> None:
                     "detail": "def some_method",
                     "documentation": {
                         "kind": "markdown",
-                        "value": "```\nsome_method(x)\n\nGreat method.\n```\n",
+                        "value": "some_method(x)\n\nGreat method.",
                     },
                     "sortText": "z",
                     "filterText": "some_method",

--- a/tests/lsp_tests/test_hover.py
+++ b/tests/lsp_tests/test_hover.py
@@ -27,7 +27,7 @@ def test_hover_on_module():
         expected = {
             "contents": {
                 "kind": "markdown",
-                "value": "```\nModule doc string for testing.\n```\n",
+                "value": "**Name:** somemodule\n\nModule doc string for testing.\n\n*Desc:* module somemodule\n*Path:* somemodule",
             },
             "range": {
                 "start": {"line": 2, "character": 7},
@@ -55,7 +55,7 @@ def test_hover_on_function():
         expected = {
             "contents": {
                 "kind": "markdown",
-                "value": "```\ndo_something()\n\nFunction doc string for testing.\n```\n",
+                "value": "**Name:** do_something\n\ndo_something()\n\nFunction doc string for testing.\n\n*Desc:* def do_something\n*Type:* do_something()\n*Path:* somemodule.do_something",
             },
             "range": {
                 "start": {"line": 4, "character": 11},
@@ -83,7 +83,7 @@ def test_hover_on_class():
         expected = {
             "contents": {
                 "kind": "markdown",
-                "value": "```\nSomeClass()\n\nClass doc string for testing.\n```\n",
+                "value": "**Name:** SomeClass\n\nSomeClass()\n\nClass doc string for testing.\n\n*Desc:* class SomeClass\n*Type:* Type[SomeClass]\n*Path:* somemodule.SomeClass",
             },
             "range": {
                 "start": {"line": 6, "character": 15},
@@ -111,7 +111,7 @@ def test_hover_on_method():
         expected = {
             "contents": {
                 "kind": "markdown",
-                "value": "```\nsome_method()\n\nMethod doc string for testing.\n```\n",
+                "value": "**Name:** some_method\n\nsome_method()\n\nMethod doc string for testing.\n\n*Desc:* def some_method\n*Path:* somemodule.SomeClass.some_method",
             },
             "range": {
                 "start": {"line": 8, "character": 2},
@@ -139,7 +139,7 @@ def test_hover_on_method_no_docstring():
         expected = {
             "contents": {
                 "kind": "markdown",
-                "value": "```\nsome_method2()\n```\n",
+                "value": "**Name:** some_method2\n\nsome_method2()\n\n*Desc:* def some_method2\n*Path:* somemodule.SomeClass.some_method2",
             },
             "range": {
                 "start": {"line": 10, "character": 2},

--- a/tests/lsp_tests/test_signature.py
+++ b/tests/lsp_tests/test_signature.py
@@ -39,7 +39,7 @@ def test_signature_help(trigger_char, column, active_param):
                     "label": "some_function(arg1: str, arg2: int, arg3: list)",
                     "documentation": {
                         "kind": "markdown",
-                        "value": "```\nThis is a test function.\n```\n",
+                        "value": "This is a test function.",
                     },
                     "parameters": [
                         {"label": "arg1: str"},


### PR DESCRIPTION
Adds:

- Full path
- Description
- Inferred type hint

Un-text-ified docstrings that aren't automatically converted to
markdown. Markdown-ish stuff was forced to plain text which I found more
annoying than the occasional piece of RST that converted
inappropriately. This commit breaks existing tests, future commit will
need to modify existing tests to expect the new docstring format.