### PR TITLE
Jedi Names may have no module_path

### DIFF
--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -72,6 +72,7 @@ def lsp_range(name: Name) -> Range:
 
 def lsp_location(name: Name) -> Location:
     """Get LSP location from Jedi definition."""
+    assert name.module_path is not None
     return Location(uri=name.module_path.as_uri(), range=lsp_range(name))
 
 

--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -70,18 +70,25 @@ def lsp_range(name: Name) -> Range:
     )
 
 
-def lsp_location(name: Name) -> Location:
+def lsp_location(name: Name) -> Optional[Location]:
     """Get LSP location from Jedi definition."""
-    assert name.module_path is not None
-    return Location(uri=name.module_path.as_uri(), range=lsp_range(name))
+    module_path = name.module_path
+    if module_path is None:
+        return None
+
+    return Location(uri=module_path.as_uri(), range=lsp_range(name))
 
 
-def lsp_symbol_information(name: Name) -> SymbolInformation:
+def lsp_symbol_information(name: Name) -> Optional[SymbolInformation]:
     """Get LSP SymbolInformation from Jedi definition."""
+    location = lsp_location(name)
+    if location is None:
+        return None
+
     return SymbolInformation(
         name=name.name,
         kind=get_lsp_symbol_type(name.type),
-        location=lsp_location(name),
+        location=location,
         container_name=(
             "None" if name is None else (name.full_name or name.name or "None")
         ),

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -285,9 +285,9 @@ def definition(
         **jedi_lines,
     )
     definitions = [
-        jedi_utils.lsp_location(name)
-        for name in names
-        if name.module_path is not None
+        definition
+        for definition in (jedi_utils.lsp_location(name) for name in names)
+        if definition is not None
     ]
     return definitions if definitions else None
 
@@ -349,9 +349,9 @@ def references(
     jedi_lines = jedi_utils.line_column(jedi_script, params.position)
     names = jedi_script.get_references(**jedi_lines)
     locations = [
-        jedi_utils.lsp_location(name)
-        for name in names
-        if name.module_path is not None
+        location
+        for location in (jedi_utils.lsp_location(name) for name in names)
+        if location is not None
     ]
     return locations if locations else None
 
@@ -387,10 +387,15 @@ def document_symbol(
     ):
         document_symbols = jedi_utils.lsp_document_symbols(names)
         return document_symbols if document_symbols else None
+
     symbol_information = [
-        jedi_utils.lsp_symbol_information(name)
-        for name in names
-        if name.module_path is not None and name.type != "param"
+        symbol_info
+        for symbol_info in (
+            jedi_utils.lsp_symbol_information(name)
+            for name in names
+            if name.type != "param"
+        )
+        if symbol_info is not None
     ]
     return symbol_information if symbol_information else None
 
@@ -426,12 +431,19 @@ def workspace_symbol(
     ignore_folders = (
         server.initialization_options.workspace.symbols.ignore_folders
     )
-    _symbols = (
-        jedi_utils.lsp_symbol_information(name)
+    unignored_names = (
+        name
         for name in names
         if name.module_path is not None
         and str(name.module_path).startswith(workspace_root)
         and not _ignore_folder(str(name.module_path), ignore_folders)
+    )
+    _symbols = (
+        symbol
+        for symbol in (
+            jedi_utils.lsp_symbol_information(name) for name in unignored_names
+        )
+        if symbol is not None
     )
     max_symbols = server.initialization_options.workspace.symbols.max_symbols
     symbols = (

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -284,7 +284,11 @@ def definition(
         follow_builtin_imports=True,
         **jedi_lines,
     )
-    definitions = [jedi_utils.lsp_location(name) for name in names]
+    definitions = [
+        jedi_utils.lsp_location(name)
+        for name in names
+        if name.module_path is not None
+    ]
     return definitions if definitions else None
 
 
@@ -344,7 +348,11 @@ def references(
     jedi_script = jedi_utils.script(server.project, document)
     jedi_lines = jedi_utils.line_column(jedi_script, params.position)
     names = jedi_script.get_references(**jedi_lines)
-    locations = [jedi_utils.lsp_location(name) for name in names]
+    locations = [
+        jedi_utils.lsp_location(name)
+        for name in names
+        if name.module_path is not None
+    ]
     return locations if locations else None
 
 
@@ -382,7 +390,7 @@ def document_symbol(
     symbol_information = [
         jedi_utils.lsp_symbol_information(name)
         for name in names
-        if name.type != "param"
+        if name.module_path is not None and name.type != "param"
     ]
     return symbol_information if symbol_information else None
 
@@ -421,7 +429,7 @@ def workspace_symbol(
     _symbols = (
         jedi_utils.lsp_symbol_information(name)
         for name in names
-        if name.module_path
+        if name.module_path is not None
         and str(name.module_path).startswith(workspace_root)
         and not _ignore_folder(str(name.module_path), ignore_folders)
     )


### PR DESCRIPTION
try to go to definition on a `NotImplementedError`, get this:
```
AttributeError: 'NoneType' object has no attribute 'as_uri'
```

Jedi names might not have a module_path.  See https://github.com/davidhalter/jedi/blob/dcea842ac237b51263c29a252dba9b650fc799ff/jedi/api/classes.py#L95.