### PR TITLE
Allow running tox test environments on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ envlist = py{36,37,38,39}{,-cov}
 isolated_build = true
 skipsdist = true
 [testenv]
-platform = linux
+platform = linux|darwin
 whitelist_externals = poetry
 skip_install = true
 commands =


### PR DESCRIPTION
The tests are cross platform and run on macOS without any issue.