### PR TITLE
Handled cases where jedi.api.classes.Name has empty line/column.

### DIFF
--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -321,8 +321,11 @@ def highlight(
     jedi_script = jedi_utils.script(server.project, document)
     jedi_lines = jedi_utils.line_column(params.position)
     names = jedi_script.get_references(*jedi_lines, scope="file")
+    lsp_ranges = [jedi_utils.lsp_range(name) for name in names]
     highlight_names = [
-        DocumentHighlight(range=jedi_utils.lsp_range(name)) for name in names
+        DocumentHighlight(range=lsp_range)
+        for lsp_range in lsp_ranges
+        if lsp_range
     ]
     return highlight_names if highlight_names else None
 

--- a/tests/lsp_tests/test_highlighting.py
+++ b/tests/lsp_tests/test_highlighting.py
@@ -167,6 +167,54 @@ HIGHLIGHTING_TEST_ROOT = TEST_DATA / "highlighting"
                 },
             ],
         ),
+        # __file__
+        (
+            {"line": 34, "character": 8},
+            [
+                {
+                    "range": {
+                        "start": {"line": 34, "character": 6},
+                        "end": {"line": 34, "character": 14},
+                    }
+                },
+            ],
+        ),
+        # __package__
+        (
+            {"line": 35, "character": 8},
+            [
+                {
+                    "range": {
+                        "start": {"line": 35, "character": 6},
+                        "end": {"line": 35, "character": 17},
+                    }
+                },
+            ],
+        ),
+        # __doc__
+        (
+            {"line": 36, "character": 8},
+            [
+                {
+                    "range": {
+                        "start": {"line": 36, "character": 6},
+                        "end": {"line": 36, "character": 13},
+                    }
+                },
+            ],
+        ),
+        # __name__
+        (
+            {"line": 37, "character": 8},
+            [
+                {
+                    "range": {
+                        "start": {"line": 37, "character": 6},
+                        "end": {"line": 37, "character": 14},
+                    }
+                },
+            ],
+        ),
     ],
 )
 def test_highlighting(position, expected):

--- a/tests/test_data/highlighting/highlighting_test1.py
+++ b/tests/test_data/highlighting/highlighting_test1.py
@@ -28,3 +28,11 @@ class SomeClass(Enum):
 instance = SomeClass()
 instance.some_method1()
 instance.some_method2()
+
+# Jedi returns an implicit definition for these special variables,
+# which has no line number.  Highlighting of usages with line numbers
+# should still function.
+print(__file__)
+print(__package__)
+print(__doc__)
+print(__name__)


### PR DESCRIPTION
This can occur for module builtins (e.g. `__name__` or `__file__`) which have a Name describing their implicit definition, but do not have a file location associated with that implicit definition.

The original symptom was a TypeError thrown in `jedi_utils.lsp_range` when hovering over `__file__`.