### PR TITLE
Dedup redundant type/kind info by simplifying full signature generation

### DIFF
--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -490,28 +490,11 @@ _SIGNATURE_TYPE_TRANSLATION = {
 def get_full_signatures(name: BaseName) -> Iterator[str]:
     """Return the full function signature with parameters."""
     signatures = name.get_signatures()
-    name_type = name.type
-    if not signatures and name_type != "class":
-        try:
-            type_hint = name.get_type_hint()
-        except Exception:  # pylint: disable=broad-except
-            # jedi randomly raises NotImplemented, TypeError, and possibly more
-            # errors here. One example from jls -
-            # test_hover.test_hover_on_method
-            type_hint = ""
-    else:
-        type_hint = ""
     if not signatures:
-        if name_type == "class":
-            yield f"class {name.name}"
-        elif name_type == "module":
-            yield f"{name.full_name} ## module"
-        elif type_hint:
-            yield f"{name.name}: {type_hint}"
-        else:
-            yield f"{name.name} ## {name_type}"
+        yield name.description
         return
-    name_type_trans = _SIGNATURE_TYPE_TRANSLATION[name_type]
+
+    name_type_trans = _SIGNATURE_TYPE_TRANSLATION[name.type]
     for signature in signatures:
         yield f"{name_type_trans} {signature.to_string()}"
 

--- a/tests/lsp_tests/test_hover.py
+++ b/tests/lsp_tests/test_hover.py
@@ -29,7 +29,7 @@ def test_hover_on_module():
         expected = {
             "contents": {
                 "kind": "markdown",
-                "value": "```python\nsomemodule ## module\n```\n---\n```text\nModule doc string for testing.\n```",
+                "value": "```python\nmodule somemodule\n```\n---\n```text\nModule doc string for testing.\n```",
             },
             "range": {
                 "start": {"line": 2, "character": 7},


### PR DESCRIPTION
For completions that don't have a signature, `BaseName.description`
provides type, name, and typing information if it was explicitly
written.  For completions that provide signatures, `.to_string` provides
the parameters and typing information that needs to be appended to the
type.

`get_type_hints()` is an expensive call that calls into `jedi.infer()`,
even for completions that have explicit typing information.

This partially reverts commit 8ee2138
by restoring the former expected behavior for how the header is rendered
when hovering over a module due to the simplified approach for obtaining
the full signatures.

Closes: #178 