### PR TITLE
Align behavior between "format" and "test" Makefile targets and update tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,9 +82,9 @@ skip_install = true
 commands =
   poetry install
 
-  !cov: poetry run black --extend-exclude test_data --check --diff jedi_language_server tests
-  !cov: poetry run docformatter --exclude test_data --check --recursive jedi_language_server tests
-  !cov: poetry run isort --check jedi_language_server tests/lsp_tests tests/lsp_test_client
+  !cov: poetry run black --check --diff jedi_language_server tests
+  !cov: poetry run docformatter --check --recursive jedi_language_server tests
+  !cov: poetry run isort --check jedi_language_server tests
 
   !cov: poetry run mypy jedi_language_server
   !cov: poetry run pylint jedi_language_server tests

--- a/tests/lsp_tests/test_refactoring.py
+++ b/tests/lsp_tests/test_refactoring.py
@@ -291,8 +291,8 @@ def test_rename_module() -> None:
                         },
                         {
                             "range": {
-                                "start": {"line": 3, "character": 4},
-                                "end": {"line": 3, "character": 4},
+                                "start": {"line": 4, "character": 4},
+                                "end": {"line": 4, "character": 4},
                             },
                             "newText": "new_",
                         },

--- a/tests/test_data/refactoring/rename_module.py
+++ b/tests/test_data/refactoring/rename_module.py
@@ -1,4 +1,5 @@
 from somepackage import somemodule
 
+
 def run():
     somemodule.bar()


### PR DESCRIPTION
`make format` runs formatting tools across all tests while `make test`
excludes some of the files or the entire `tests/` directory entirely.
Since many editors may run these tools directly on files being edited
instead of understanding the Makefile targets to execute, this change
move towards run formatting tools across the entire directory structure
to favor `make test` being successful after `make format` is executed.

Align the tests now that `make format` has been applied.
