### PR TITLE
More infotext standardization

### DIFF
--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -503,13 +503,15 @@ def get_full_signatures(name: BaseName) -> Iterator[str]:
         type_hint = ""
     if not signatures:
         if name_type == "class":
-            yield f"class {name.name}"
+            yield f"class {name.name}()"
+        elif name_type == "function":
+            yield f"def {name.name}()"
         elif name_type == "module":
-            yield f"{name.full_name} ## module"
+            yield f"{name.full_name}"
         elif type_hint:
             yield f"{name.name}: {type_hint}"
         else:
-            yield f"{name.name} ## {name_type}"
+            yield f"{name.name}"
         return
     name_type_trans = _SIGNATURE_TYPE_TRANSLATION[name_type]
     for signature in signatures:
@@ -554,30 +556,28 @@ def hover_text(
     name = names[0]
     if _hover_ignore(name, initialization_options):
         return None
+    name_type = name.type
     full_name = name.full_name
-    description = name.description
     docstring = name.docstring(raw=True)
     header_plain = "\n".join(get_full_signatures(name))
     header = _md_python(header_plain, markup_kind)
     result: List[str] = []
     result.append(header)
-    if docstring:
-        result.append("---")
-        result.append(convert_docstring(docstring, markup_kind))
-    elif header_plain.startswith(description):
-        pass
-    else:
-        result.append("---")
-        result.append(_md_python(description, markup_kind))
-
-    if full_name and name.type != "module":
-        if len(result) == 1:
-            result.append("---")
+    result.append("---")
+    result.append(
+        _md_italic("jedi type:", markup_kind)
+        + " "
+        + _md_text_sl(name_type, markup_kind)
+    )
+    if full_name and name_type != "module":
         result.append(
-            _md_bold("Full name:", markup_kind)
+            _md_italic("full name:", markup_kind)
             + " "
             + _md_text_sl(full_name, markup_kind)
         )
+    if docstring:
+        result.append(convert_docstring(docstring, markup_kind))
+
     return "\n".join(result).strip()
 
 

--- a/tests/lsp_tests/test_hover.py
+++ b/tests/lsp_tests/test_hover.py
@@ -29,7 +29,7 @@ def test_hover_on_module():
         expected = {
             "contents": {
                 "kind": "markdown",
-                "value": "```python\nsomemodule ## module\n```\n---\n```text\nModule doc string for testing.\n```",
+                "value": "```python\nsomemodule\n```\n---\n*jedi type:* `module`\n```text\nModule doc string for testing.\n```",
             },
             "range": {
                 "start": {"line": 2, "character": 7},
@@ -57,7 +57,7 @@ def test_hover_on_function():
         expected = {
             "contents": {
                 "kind": "markdown",
-                "value": "```python\ndef do_something()\n```\n---\n```text\nFunction doc string for testing.\n```\n**Full name:** `somemodule.do_something`",
+                "value": "```python\ndef do_something()\n```\n---\n*jedi type:* `function`\n*full name:* `somemodule.do_something`\n```text\nFunction doc string for testing.\n```",
             },
             "range": {
                 "start": {"line": 4, "character": 11},
@@ -85,7 +85,7 @@ def test_hover_on_class():
         expected = {
             "contents": {
                 "kind": "markdown",
-                "value": "```python\nclass SomeClass()\n```\n---\n```text\nClass doc string for testing.\n```\n**Full name:** `somemodule.SomeClass`",
+                "value": "```python\nclass SomeClass()\n```\n---\n*jedi type:* `class`\n*full name:* `somemodule.SomeClass`\n```text\nClass doc string for testing.\n```",
             },
             "range": {
                 "start": {"line": 6, "character": 15},
@@ -113,7 +113,7 @@ def test_hover_on_method():
         expected = {
             "contents": {
                 "kind": "markdown",
-                "value": "```python\ndef some_method()\n```\n---\n```text\nMethod doc string for testing.\n```\n**Full name:** `somemodule.SomeClass.some_method`",
+                "value": "```python\ndef some_method()\n```\n---\n*jedi type:* `function`\n*full name:* `somemodule.SomeClass.some_method`\n```text\nMethod doc string for testing.\n```",
             },
             "range": {
                 "start": {"line": 8, "character": 2},
@@ -141,7 +141,7 @@ def test_hover_on_method_no_docstring():
         expected = {
             "contents": {
                 "kind": "markdown",
-                "value": "```python\ndef some_method2()\n```\n---\n**Full name:** `somemodule.SomeClass.some_method2`",
+                "value": "```python\ndef some_method2()\n```\n---\n*jedi type:* `function`\n*full name:* `somemodule.SomeClass.some_method2`",
             },
             "range": {
                 "start": {"line": 10, "character": 2},


### PR DESCRIPTION
 Standardize hover text and adjust signature accordingly

Hover text requires more information embedded inside of it than other
types of information text. Completion items have more structured
information than Hover text. For this reason, structured information is
provided directly in Hover text and omitted from the signature (which is
used everywhere).

Fixes https://github.com/pappasam/jedi-language-server/issues/178