### PR TITLE
Test that classes without arguments contain parentheses in signature

### DIFF
--- a/tests/lsp_tests/test_completion.py
+++ b/tests/lsp_tests/test_completion.py
@@ -161,3 +161,43 @@ def test_lsp_completion_class_method() -> None:
             ],
         }
         assert_that(actual, is_(expected))
+
+
+def test_lsp_completion_class_noargs() -> None:
+    """Checks if classes without arguments include parenthesis in signature."""
+    with session.LspSession() as ls_session:
+        # Initialize, asking for eager resolution.
+        initialize_params = copy.deepcopy(VSCODE_DEFAULT_INITIALIZE)
+        initialize_params["initializationOptions"] = {
+            "completion": {"resolveEagerly": True}
+        }
+        ls_session.initialize(initialize_params)
+
+        uri = as_uri(COMPLETION_TEST_ROOT / "completion_test2.py")
+        actual = ls_session.text_document_completion(
+            {
+                "textDocument": {"uri": uri},
+                "position": {"line": 7, "character": 3},
+                "context": {"triggerKind": 1},
+            }
+        )
+
+        expected = {
+            "isIncomplete": False,
+            "items": [
+                {
+                    "label": "MyClass",
+                    "kind": 7,
+                    "detail": "class MyClass()",
+                    "documentation": {
+                        "kind": "markdown",
+                        "value": "```text\nSimple class.\n```",
+                    },
+                    "sortText": "z",
+                    "filterText": "MyClass",
+                    "insertText": "MyClass()$0",
+                    "insertTextFormat": 2,
+                }
+            ],
+        }
+        assert_that(actual, is_(expected))

--- a/tests/test_data/completion/completion_test2.py
+++ b/tests/test_data/completion/completion_test2.py
@@ -1,0 +1,8 @@
+"""Test file for test_completion."""
+
+
+class MyClass:
+    """Simple class."""
+
+
+MyC


### PR DESCRIPTION
Hey, @pappasam I noticed cfd2e7a and added a test case that I think covers the situation you were describing.

~~In my testing, it appears that `.description()` does include the parenthesis from Jedi.  I hope you don't mind me reverting cfd2e7a towards keeping the code path simple now that there is a test in place.  If there is a different situation that you are running into, I'm happy to iterate on the PR and ensure that case is covered.~~