### PR TITLE
Change logging level to avoid flooding terminal

### DIFF
--- a/jedi_language_server/cli.py
+++ b/jedi_language_server/cli.py
@@ -103,7 +103,7 @@ Notes:
             file=sys.stderr,
         )
         sys.exit(1)
-    log_level = {0: logging.INFO, 1: logging.DEBUG}.get(
+    log_level = {0: logging.WARN, 1: logging.INFO, 2:logging.DEBUG}.get(
         args.verbose,
         logging.DEBUG,
     )

--- a/jedi_language_server/cli.py
+++ b/jedi_language_server/cli.py
@@ -103,7 +103,7 @@ Notes:
             file=sys.stderr,
         )
         sys.exit(1)
-    log_level = {0: logging.WARN, 1: logging.INFO, 2:logging.DEBUG}.get(
+    log_level = {0: logging.WARN, 1: logging.INFO, 2: logging.DEBUG}.get(
         args.verbose,
         logging.DEBUG,
     )


### PR DESCRIPTION
In JupyterLab the jedi-language-server floods the console with the default `INFO` logging level. This increase the default to `WARN` but still allows other levels using the verbose option.

This fixes https://github.com/pappasam/jedi-language-server/issues/186.
