### PR TITLE
Require poetry-core instead of poetry as build dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry>=1.0.5"]
+requires = ["poetry-core>=1.0.5"]
 build-backend = "poetry.masonry.api"
 
 [tool.black]


### PR DESCRIPTION
Hi, thanks for `jedi-language-server`!

This proposes using the lighter-weight `poetry-core` as the build-time dependency. This helps downstreams, as some of  "full fat" `poetry`'s dependencies have been a little more unstable recently.