### PR TITLE
import from correct module in build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["poetry-core>=1.0.5"]
-build-backend = "poetry.masonry.api"
+build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
Thanks to @dimbleby's comment https://github.com/pappasam/jedi-language-server/pull/205#pullrequestreview-958481827, this ensures the correct build backend is imported, as per the [poetry documentation](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517).