### PR TITLE
pygls 1.0.0a0

### DIFF
--- a/jedi_language_server/__init__.py
+++ b/jedi_language_server/__init__.py
@@ -1,1 +1,9 @@
 """Jedi Language Server."""
+import sys
+
+if sys.version_info < (3, 8):
+    from importlib_metadata import version
+else:
+    from importlib.metadata import version
+
+__version__ = version("jedi-language-server")

--- a/jedi_language_server/cli.py
+++ b/jedi_language_server/cli.py
@@ -4,31 +4,13 @@ import argparse
 import logging
 import sys
 
+from . import __version__
 from .server import SERVER
 
 
 def get_version() -> str:
     """Get the program version."""
-    # pylint: disable=import-outside-toplevel
-    try:
-        # Type checker for Python < 3.8 fails.
-        # Since this ony happens here, we just ignore.
-        from importlib.metadata import version  # type: ignore
-    except ImportError:
-        try:
-            # Below ignored both because this a redefinition from above, and
-            # because importlib_metadata isn't known by mypy. Ignored because
-            # this is intentional.
-            from importlib_metadata import version  # type: ignore
-        except ImportError:
-            print(
-                "Error: unable to get version. "
-                "If using Python < 3.8, you must install "
-                "`importlib_metadata` to get the version.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-    return version("jedi-language-server")
+    return __version__
 
 
 def cli() -> None:

--- a/jedi_language_server/initialization_options.py
+++ b/jedi_language_server/initialization_options.py
@@ -6,8 +6,8 @@ initialization options.
 
 from typing import List, Optional, Pattern, Set
 
+from lsprotocol.types import MarkupKind
 from pydantic import BaseModel, Field
-from pygls.lsp.types import MarkupKind
 
 # pylint: disable=missing-class-docstring
 # pylint: disable=too-few-public-methods

--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -150,14 +150,23 @@ def lsp_document_symbols(names: List[Name]) -> List[DocumentSymbol]:
     accessible with dot notation are removed from display. See comments
     inline for cleaning steps.
     """
+    # pylint: disable=too-many-branches
     _name_lookup: Dict[Name, DocumentSymbol] = {}
     results: List[DocumentSymbol] = []
     for name in names:
+        symbol_range = _document_symbol_range(name)
+        if symbol_range is None:
+            continue
+
+        selection_range = lsp_range(name)
+        if selection_range is None:
+            continue
+
         symbol = DocumentSymbol(
             name=name.name,
             kind=get_lsp_symbol_type(name.type),
-            range=_document_symbol_range(name),
-            selection_range=lsp_range(name),
+            range=symbol_range,
+            selection_range=selection_range,
             detail=name.description,
             children=[],
         )

--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -13,7 +13,7 @@ import jedi.inference.references
 import jedi.settings
 from jedi import Project, Script
 from jedi.api.classes import BaseName, Completion, Name, ParamName, Signature
-from pygls.lsp.types import (
+from lsprotocol.types import (
     CompletionItem,
     CompletionItemKind,
     Diagnostic,

--- a/jedi_language_server/pygls_utils.py
+++ b/jedi_language_server/pygls_utils.py
@@ -6,7 +6,7 @@ Helper functions that simplify working with pygls
 
 from typing import Optional
 
-from pygls.lsp.types import Position, Range
+from lsprotocol.types import Position, Range
 from pygls.workspace import Document
 
 

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -9,7 +9,7 @@ Official language server spec:
 import itertools
 from typing import Any, List, Optional, Union
 
-from jedi import Project
+from jedi import Project, __version__
 from jedi.api.refactoring import RefactoringError
 from lsprotocol.types import (
     COMPLETION_ITEM_RESOLVE,
@@ -159,7 +159,11 @@ class JediLanguageServer(LanguageServer):
         super().__init__(*args, **kwargs)
 
 
-SERVER = JediLanguageServer(protocol_cls=JediLanguageServerProtocol)
+SERVER = JediLanguageServer(
+    name="jedi-language-server",
+    version=__version__,
+    protocol_cls=JediLanguageServerProtocol,
+)
 
 
 # Server capabilities

--- a/jedi_language_server/text_edit_utils.py
+++ b/jedi_language_server/text_edit_utils.py
@@ -11,12 +11,11 @@ from bisect import bisect_right
 from typing import Iterator, List, NamedTuple, Union
 
 from jedi.api.refactoring import ChangedFile, Refactoring
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Position,
     Range,
     RenameFile,
     RenameFileOptions,
-    ResourceOperationKind,
     TextDocumentEdit,
     TextEdit,
     VersionedTextDocumentIdentifier,
@@ -59,7 +58,7 @@ class RefactoringConverter:
         """Get all File rename operations."""
         for old_name, new_name in self.refactoring.get_renames():
             yield RenameFile(
-                kind=ResourceOperationKind.Rename,
+                kind="rename",
                 old_uri=old_name.as_uri(),
                 new_uri=new_name.as_uri(),
                 options=RenameFileOptions(

--- a/jedi_language_server/type_map.py
+++ b/jedi_language_server/type_map.py
@@ -1,6 +1,6 @@
 """Jedi types mapped to LSP types."""
 
-from pygls.lsp.types import CompletionItemKind, SymbolKind
+from lsprotocol.types import CompletionItemKind, SymbolKind
 
 # See docs:
 # https://jedi.readthedocs.io/en/latest/docs/api-classes.html?highlight=type#jedi.api.classes.BaseName.type

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,5 +4,8 @@ plugins = pydantic.mypy
 [mypy-jedi.*]
 ignore_missing_imports = True
 
+[mypy-lsprotocol.*]
+ignore_missing_imports = True
+
 [mypy-pygls.*]
 no_implicit_reexport = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,8 +4,5 @@ plugins = pydantic.mypy
 [mypy-jedi.*]
 ignore_missing_imports = True
 
-[mypy-lsprotocol.*]
-ignore_missing_imports = True
-
 [mypy-pygls.*]
 no_implicit_reexport = False

--- a/poetry.lock
+++ b/poetry.lock
@@ -17,7 +17,7 @@ wrapt = ">=1.11,<2"
 name = "attrs"
 version = "22.1.0"
 description = "Classes Without Boilerplate"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
 
@@ -49,6 +49,19 @@ colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.7.4)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "cattrs"
+version = "22.2.0"
+description = "Composable complex class support for attrs and dataclasses."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+attrs = ">=20"
+exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
+typing_extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "cfgv"
@@ -138,7 +151,7 @@ python-versions = ">=3.6"
 name = "exceptiongroup"
 version = "1.0.0rc9"
 description = "Backport of PEP 654 (exception groups)"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -228,6 +241,18 @@ description = "A fast and thorough lazy object proxy."
 category = "dev"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "lsprotocol"
+version = "2022.0.0a6"
+description = "Python implementation of the Language Server Protocol."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+attrs = "*"
+cattrs = "*"
 
 [[package]]
 name = "mccabe"
@@ -375,17 +400,14 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pygls"
-version = "0.12.4"
+version = "1.0.0a0"
 description = "a pythonic generic language server (pronounced like \"pie glass\")."
 category = "main"
 optional = false
-python-versions = "<3.12,>=3.7"
+python-versions = "<4,>=3.7"
 
 [package.dependencies]
-pydantic = [
-    {version = ">=1.9.1", markers = "python_version < \"3.11\""},
-    {version = ">=1.10.2", markers = "python_version >= \"3.11\""},
-]
+lsprotocol = "*"
 typeguard = ">=2.10.0,<3"
 
 [package.extras]
@@ -676,7 +698,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7,<3.12"
-content-hash = "26919e399ba6cf8713269bfcc577f508d4ca43ba448b7eed9edb5e3f0a50b442"
+content-hash = "1955b8e1640abadfb599c73552430b4d4031835487bbff09c6a86f3140905dd0"
 
 [metadata.files]
 astroid = [
@@ -709,6 +731,10 @@ black = [
     {file = "black-22.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de"},
     {file = "black-22.10.0-py3-none-any.whl", hash = "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458"},
     {file = "black-22.10.0.tar.gz", hash = "sha256:f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1"},
+]
+cattrs = [
+    {file = "cattrs-22.2.0-py3-none-any.whl", hash = "sha256:bc12b1f0d000b9f9bee83335887d532a1d3e99a833d1bf0882151c97d3e68c21"},
+    {file = "cattrs-22.2.0.tar.gz", hash = "sha256:f0eed5642399423cf656e7b66ce92cdc5b963ecafd041d1b24d136fdde7acf6d"},
 ]
 cfgv = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
@@ -857,6 +883,10 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:677ea950bef409b47e51e733283544ac3d660b709cfce7b187f5ace137960d61"},
     {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
 ]
+lsprotocol = [
+    {file = "lsprotocol-2022.0.0a6-py3-none-any.whl", hash = "sha256:23b54c3dded374db421ccc496b5172481d057dab66657812897b17f046e13c9f"},
+    {file = "lsprotocol-2022.0.0a6.tar.gz", hash = "sha256:00dce9538cca7858e02d97aac08cdd023f2d2a87b7252d80f21f2e863a523a37"},
+]
 mccabe = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
     {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
@@ -962,8 +992,8 @@ pydantic = [
     {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
 ]
 pygls = [
-    {file = "pygls-0.12.4-py3-none-any.whl", hash = "sha256:1b96378452217a02f19d89d9e647a4256d8d445ab3c641a589b4f73bf11898b6"},
-    {file = "pygls-0.12.4.tar.gz", hash = "sha256:63b859411307ed6f99fb9dd0e71be507a17ae9b3de5c5d07c497f5bddadcc46a"},
+    {file = "pygls-1.0.0a0-py3-none-any.whl", hash = "sha256:04f06039c94024aaf282b25d4add2ec6077278d08ff8d0bab0cc2be7c6167d53"},
+    {file = "pygls-1.0.0a0.tar.gz", hash = "sha256:652cc981f0f68f717b294a91ff38142b8035c9cefe954df05121ce1dc0f69712"},
 ]
 pyhamcrest = [
     {file = "pyhamcrest-2.0.4-py3-none-any.whl", hash = "sha256:60a41d4783b9d56c9ec8586635d2301db5072b3ea8a51c32dd03c408ae2b0f79"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -244,7 +244,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "lsprotocol"
-version = "2022.0.0a7"
+version = "2022.0.0a9"
 description = "Python implementation of the Language Server Protocol."
 category = "main"
 optional = false
@@ -400,7 +400,7 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pygls"
-version = "1.0.0a2"
+version = "1.0.0a3"
 description = "a pythonic generic language server (pronounced like \"pie glass\")."
 category = "main"
 optional = false
@@ -698,7 +698,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7,<3.12"
-content-hash = "ff7b819c2b8ed659a53460e2b5fb2533651a64a82472306cc1a6d6375162103a"
+content-hash = "91b8fab325933c92dcdfd0a76347759b8d4c22a7a5d0fe441ddfc9767c501743"
 
 [metadata.files]
 astroid = [
@@ -884,8 +884,8 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
 ]
 lsprotocol = [
-    {file = "lsprotocol-2022.0.0a7-py3-none-any.whl", hash = "sha256:3a4fef9869faffda4b6485383d72e4fa79554f6bcb55862fcd9b8584f0a64b40"},
-    {file = "lsprotocol-2022.0.0a7.tar.gz", hash = "sha256:01b92d612a1fd792f62f0f8e7c226cf4fa7528a933ed70b3d7b00bf887c863b9"},
+    {file = "lsprotocol-2022.0.0a9-py3-none-any.whl", hash = "sha256:e4bc3d2ed71045f64cbe4d053bd6d45300a77b122b372a383914ce4ddb9c62d4"},
+    {file = "lsprotocol-2022.0.0a9.tar.gz", hash = "sha256:db81eafc80485a6052f6771aaf6fb9cef58cb6409d510c60132f12c6e91d9182"},
 ]
 mccabe = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
@@ -992,8 +992,8 @@ pydantic = [
     {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
 ]
 pygls = [
-    {file = "pygls-1.0.0a2-py3-none-any.whl", hash = "sha256:d1066ed41806d7d72675692679e47ef481f3dd84e748530997fe5352163b88be"},
-    {file = "pygls-1.0.0a2.tar.gz", hash = "sha256:935419f88e2733475f6f3ccb0c2f458b06b771813181b3601e26182ad21b5df2"},
+    {file = "pygls-1.0.0a3-py3-none-any.whl", hash = "sha256:91e6c9607e8ffadbe4541ef8763459385557a0b092c8a505206698fff632a59e"},
+    {file = "pygls-1.0.0a3.tar.gz", hash = "sha256:ecc931ab68b07809c22b400c3f2caa61a427094c0f2559b0e06c7008b90ddbb3"},
 ]
 pyhamcrest = [
     {file = "pyhamcrest-2.0.4-py3-none-any.whl", hash = "sha256:60a41d4783b9d56c9ec8586635d2301db5072b3ea8a51c32dd03c408ae2b0f79"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -400,7 +400,7 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pygls"
-version = "1.0.0a3"
+version = "1.0.0"
 description = "a pythonic generic language server (pronounced like \"pie glass\")."
 category = "main"
 optional = false
@@ -698,7 +698,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7,<3.12"
-content-hash = "91b8fab325933c92dcdfd0a76347759b8d4c22a7a5d0fe441ddfc9767c501743"
+content-hash = "4a1f233b12b4af826751f4329abb8c9a7b7e75e80f58227ec6e3cd5420ef30a6"
 
 [metadata.files]
 astroid = [
@@ -992,8 +992,8 @@ pydantic = [
     {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
 ]
 pygls = [
-    {file = "pygls-1.0.0a3-py3-none-any.whl", hash = "sha256:91e6c9607e8ffadbe4541ef8763459385557a0b092c8a505206698fff632a59e"},
-    {file = "pygls-1.0.0a3.tar.gz", hash = "sha256:ecc931ab68b07809c22b400c3f2caa61a427094c0f2559b0e06c7008b90ddbb3"},
+    {file = "pygls-1.0.0-py3-none-any.whl", hash = "sha256:3414594ac29ff3ab990f004c675d1077e4e2659eae5cc3ae67cc6fa4d861e342"},
+    {file = "pygls-1.0.0.tar.gz", hash = "sha256:c2a1c22e30028f7ca9d3f0a04da8eef29f0f1701bdbd97d8614d8e1e6711f336"},
 ]
 pyhamcrest = [
     {file = "pyhamcrest-2.0.4-py3-none-any.whl", hash = "sha256:60a41d4783b9d56c9ec8586635d2301db5072b3ea8a51c32dd03c408ae2b0f79"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -698,7 +698,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7,<3.12"
-content-hash = "f1963723c3d0c7592fcefc000c673e22436817ab1e5af28d08491a131480163a"
+content-hash = "ff7b819c2b8ed659a53460e2b5fb2533651a64a82472306cc1a6d6375162103a"
 
 [metadata.files]
 astroid = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -698,7 +698,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7,<3.12"
-content-hash = "1955b8e1640abadfb599c73552430b4d4031835487bbff09c6a86f3140905dd0"
+content-hash = "02f10d3a781a9489552d27caa109f773e47d1cb9e1dd705b356d5169abd5818c"
 
 [metadata.files]
 astroid = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -244,7 +244,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "lsprotocol"
-version = "2022.0.0a6"
+version = "2022.0.0a7"
 description = "Python implementation of the Language Server Protocol."
 category = "main"
 optional = false
@@ -400,11 +400,11 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pygls"
-version = "1.0.0a0"
+version = "1.0.0a2"
 description = "a pythonic generic language server (pronounced like \"pie glass\")."
 category = "main"
 optional = false
-python-versions = "<4,>=3.7"
+python-versions = "<3.12,>=3.7"
 
 [package.dependencies]
 lsprotocol = "*"
@@ -698,7 +698,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7,<3.12"
-content-hash = "02f10d3a781a9489552d27caa109f773e47d1cb9e1dd705b356d5169abd5818c"
+content-hash = "f1963723c3d0c7592fcefc000c673e22436817ab1e5af28d08491a131480163a"
 
 [metadata.files]
 astroid = [
@@ -884,8 +884,8 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
 ]
 lsprotocol = [
-    {file = "lsprotocol-2022.0.0a6-py3-none-any.whl", hash = "sha256:23b54c3dded374db421ccc496b5172481d057dab66657812897b17f046e13c9f"},
-    {file = "lsprotocol-2022.0.0a6.tar.gz", hash = "sha256:00dce9538cca7858e02d97aac08cdd023f2d2a87b7252d80f21f2e863a523a37"},
+    {file = "lsprotocol-2022.0.0a7-py3-none-any.whl", hash = "sha256:3a4fef9869faffda4b6485383d72e4fa79554f6bcb55862fcd9b8584f0a64b40"},
+    {file = "lsprotocol-2022.0.0a7.tar.gz", hash = "sha256:01b92d612a1fd792f62f0f8e7c226cf4fa7528a933ed70b3d7b00bf887c863b9"},
 ]
 mccabe = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
@@ -992,8 +992,8 @@ pydantic = [
     {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
 ]
 pygls = [
-    {file = "pygls-1.0.0a0-py3-none-any.whl", hash = "sha256:04f06039c94024aaf282b25d4add2ec6077278d08ff8d0bab0cc2be7c6167d53"},
-    {file = "pygls-1.0.0a0.tar.gz", hash = "sha256:652cc981f0f68f717b294a91ff38142b8035c9cefe954df05121ce1dc0f69712"},
+    {file = "pygls-1.0.0a2-py3-none-any.whl", hash = "sha256:d1066ed41806d7d72675692679e47ef481f3dd84e748530997fe5352163b88be"},
+    {file = "pygls-1.0.0a2.tar.gz", hash = "sha256:935419f88e2733475f6f3ccb0c2f458b06b771813181b3601e26182ad21b5df2"},
 ]
 pyhamcrest = [
     {file = "pyhamcrest-2.0.4-py3-none-any.whl", hash = "sha256:60a41d4783b9d56c9ec8586635d2301db5072b3ea8a51c32dd03c408ae2b0f79"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ pygls = "^1.0.0a0"
 pydantic = "^1.9.1"
 docstring-to-markdown = "0.*"
 importlib-metadata = { version = "^3.10.1", python = "~3.7" }
-lsprotocol = "^2022.0.0a5"
+lsprotocol = "^2022.0.0a6"
 
 [tool.poetry.dev-dependencies]
 pre-commit = ">=2.19.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,11 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.7,<3.12"
 jedi = "^0.18.1"
-pygls = "^0.12.4"
+pygls = "^1.0.0a0"
 pydantic = "^1.9.1"
 docstring-to-markdown = "0.*"
 importlib-metadata = { version = "^3.10.1", python = "~3.7" }
+lsprotocol = "^2022.0.0a5"
 
 [tool.poetry.dev-dependencies]
 pre-commit = ">=2.19.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,11 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.7,<3.12"
 jedi = "^0.18.1"
-pygls = "^1.0.0a2"
+pygls = "^1.0.0a3"
 pydantic = "^1.9.1"
 docstring-to-markdown = "0.*"
 importlib-metadata = { version = "^3.10.1", python = "~3.7" }
-lsprotocol = ">=2022.0.0a7"
+lsprotocol = ">=2022.0.0a9"
 
 [tool.poetry.dev-dependencies]
 pre-commit = ">=2.19.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ pygls = "^1.0.0a2"
 pydantic = "^1.9.1"
 docstring-to-markdown = "0.*"
 importlib-metadata = { version = "^3.10.1", python = "~3.7" }
-lsprotocol = "^2022.0.0a7"
+lsprotocol = ">=2022.0.0a7"
 
 [tool.poetry.dev-dependencies]
 pre-commit = ">=2.19.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.7,<3.12"
 jedi = "^0.18.1"
-pygls = "^1.0.0a3"
+pygls = "^1.0.0"
 pydantic = "^1.9.1"
 docstring-to-markdown = "0.*"
 importlib-metadata = { version = "^3.10.1", python = "~3.7" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,11 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.7,<3.12"
 jedi = "^0.18.1"
-pygls = "^1.0.0a0"
+pygls = "^1.0.0a2"
 pydantic = "^1.9.1"
 docstring-to-markdown = "0.*"
 importlib-metadata = { version = "^3.10.1", python = "~3.7" }
-lsprotocol = "^2022.0.0a6"
+lsprotocol = "^2022.0.0a7"
 
 [tool.poetry.dev-dependencies]
 pre-commit = ">=2.19.0"

--- a/tests/lsp_test_client/session.py
+++ b/tests/lsp_test_client/session.py
@@ -107,6 +107,8 @@ class LspSession(MethodDispatcher):
 
     def initialized(self, initialized_params=None):
         """Sends the initialized notification to LSP server."""
+        if initialized_params is None:
+            initialized_params = {}
         self._endpoint.notify("initialized", initialized_params)
 
     def shutdown(self, should_exit, exit_timeout=LSP_EXIT_TIMEOUT):

--- a/tests/lsp_tests/test_references.py
+++ b/tests/lsp_tests/test_references.py
@@ -182,7 +182,7 @@ def test_references(position, expected):
                 "textDocument": {"uri": uri},
                 "position": position,
                 "context": {
-                    "include_declaration": True,
+                    "includeDeclaration": True,
                 },
             }
         )


### PR DESCRIPTION
pygls is going 1.0, and the main change is that they're migrating away  from their homegrown pydantic models for the protocol and using https://pypi.org/project/lsprotocol/ (https://github.com/microsoft/lsprotocol) - which seems to be autogenerated (and uses cattrs).

that turns out not to be a tremendously impactful change: a few things get renamed in more-or-less obvious ways, the validation gets slightly stricter in a couple of places, that's about it.

I don't expect you'll want to merge / publish before they _actually_ go 1.0.0.  But if and when you're happy that this seems anyway not worse than before, I expect they'd be glad to hear about it in https://github.com/openlawlibrary/pygls/pull/273