### PR TITLE
Add "environmentPath" init option, for Jedi "environment_path"

### DIFF
--- a/jedi_language_server/initialization_options.py
+++ b/jedi_language_server/initialization_options.py
@@ -4,7 +4,7 @@ Provides a fully defaulted pydantic model for this language server's
 initialization options.
 """
 
-from typing import List, Optional, Pattern, Set
+from typing import List, Optional, Pattern, Set, Union
 
 from pydantic import BaseModel, Field
 from pygls.lsp.types import MarkupKind
@@ -104,7 +104,7 @@ class Symbols(Model):
 
 
 class Workspace(Model):
-    environment_path: str | None = None
+    environment_path: Union[str, None] = None
     extra_paths: List[str] = []
     symbols: Symbols = Symbols()
 

--- a/jedi_language_server/initialization_options.py
+++ b/jedi_language_server/initialization_options.py
@@ -104,6 +104,7 @@ class Symbols(Model):
 
 
 class Workspace(Model):
+    environment_path: str | None = None
     extra_paths: List[str] = []
     symbols: Symbols = Symbols()
 

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -132,7 +132,7 @@ class JediLanguageServerProtocol(LanguageServerProtocol):
         server.project = (
             Project(
                 path=server.workspace.root_path,
-                environment_path=initialization_options.environment_path,
+                environment_path=initialization_options.workspace.environment_path,
                 added_sys_path=initialization_options.workspace.extra_paths,
                 smart_sys_path=True,
                 load_unsafe_extensions=False,

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -132,6 +132,7 @@ class JediLanguageServerProtocol(LanguageServerProtocol):
         server.project = (
             Project(
                 path=server.workspace.root_path,
+                environment_path=initialization_options.environment_path,
                 added_sys_path=initialization_options.workspace.extra_paths,
                 smart_sys_path=True,
                 load_unsafe_extensions=False,

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -129,11 +129,12 @@ class JediLanguageServerProtocol(LanguageServerProtocol):
             server.feature(HOVER)(hover)
 
         initialize_result: InitializeResult = super().lsp_initialize(params)
+        workspace_options = initialization_options.workspace
         server.project = (
             Project(
                 path=server.workspace.root_path,
-                environment_path=initialization_options.workspace.environment_path,
-                added_sys_path=initialization_options.workspace.extra_paths,
+                environment_path=workspace_options.environment_path,
+                added_sys_path=workspace_options.extra_paths,
                 smart_sys_path=True,
                 load_unsafe_extensions=False,
             )


### PR DESCRIPTION
This PR is intended to address the feature request in #199.

I'm not sure how to formally test this, but I have confirmed that it works as follows.

First, set up two venvs: one with this branch `pip install`-ed, and another with a nontrivial library dependency:

```bash
git clone https://gwerbin/jedi-language-server gwerbin_jedi-language-server
cd gwerbin_jedi-language-server

python -m venv ./jedi-env
./jedi-env/bin/pip install -e .

python -m venv ./work-env
./work-env/bin/pip install -U numpy
```

Then configure the following in [Neovim LSP Config](https://github.com/neovim/nvim-lspconfig):

```lua
    lspconfig.jedi_language_server.setup({
      cmd = { '/path/to/jedi-env/bin/jedi-language-server' },
      on_new_config = function(new_config, root_dir)
        new_config.init_options = {
          workspace = {
            environmentPath = '/path/to/work-env/bin/python',
          },
        }
      end,
    }))

```

Finally, use Neovim to create a new Python file called `nptest.py`. You should be able to write `import numpy as np` at the top of the file and see Jedi completions for Numpy with `np.<tab>`, e.g. `np.random.default_rng()`.

Confirm also that if you remove `cmd = ` from the Neovim config above, that Numpy library completion no longer works when editing `nptest.py`.