### PR TITLE
don't install readme to top-level site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ classifiers = [
   "Topic :: Utilities",
   "Typing :: Typed",
 ]
-include = ["README.md"]
 license = "MIT"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
otherwise it is placed in, e.g., `/usr/lib/python3.11/site-packages/README.txt`