### PR TITLE
Fix handling of initialization options following removal of pydantic

### DIFF
--- a/jedi_language_server/initialization_options.py
+++ b/jedi_language_server/initialization_options.py
@@ -4,6 +4,7 @@ Provides a fully defaulted pydantic model for this language server's
 initialization options.
 """
 
+import re
 from dataclasses import dataclass, field, fields, is_dataclass
 from typing import Any, List, Optional, Pattern, Set
 
@@ -148,4 +149,15 @@ def structure(cls: type) -> Any:
 
 initialization_options_converter.register_structure_hook_factory(
     is_dataclass, structure
+)
+
+
+initialization_options_converter.register_structure_hook_factory(
+    lambda x: x == Pattern[str],
+    lambda _: lambda x, _: re.compile(x),
+)
+
+initialization_options_converter.register_unstructure_hook_factory(
+    lambda x: x == Pattern[str],
+    lambda _: lambda x: x.pattern,
 )

--- a/jedi_language_server/initialization_options.py
+++ b/jedi_language_server/initialization_options.py
@@ -5,6 +5,7 @@ initialization options.
 """
 
 import re
+import sys
 from dataclasses import dataclass, field, fields, is_dataclass
 from typing import Any, List, Optional, Pattern, Set
 
@@ -15,7 +16,11 @@ from lsprotocol.types import MarkupKind
 # pylint: disable=missing-class-docstring
 # pylint: disable=too-few-public-methods
 
-light_dataclass = dataclass(kw_only=True, eq=False, match_args=False)
+if sys.version_info >= (3, 10):
+    # pylint: disable-next=unexpected-keyword-arg
+    light_dataclass = dataclass(kw_only=True, eq=False, match_args=False)
+else:
+    light_dataclass = dataclass(eq=False)
 
 
 @light_dataclass

--- a/jedi_language_server/initialization_options.py
+++ b/jedi_language_server/initialization_options.py
@@ -4,10 +4,9 @@ Provides a fully defaulted pydantic model for this language server's
 initialization options.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields, is_dataclass
 from typing import Any, List, Optional, Pattern, Set
 
-from attrs import fields, has
 from cattrs import Converter
 from cattrs.gen import make_dict_structure_fn, override
 from lsprotocol.types import MarkupKind
@@ -148,5 +147,5 @@ def structure(cls: type) -> Any:
 
 
 initialization_options_converter.register_structure_hook_factory(
-    has, structure
+    is_dataclass, structure
 )

--- a/tests/test_initialization_options.py
+++ b/tests/test_initialization_options.py
@@ -4,13 +4,16 @@ import re
 
 from hamcrest import assert_that, is_
 
-from jedi_language_server.initialization_options import InitializationOptions
+from jedi_language_server.initialization_options import (
+    InitializationOptions,
+    initialization_options_converter,
+)
 
 
 def test_initialization_options() -> None:
     """Test our adjustments to parsing of the initialization options."""
 
-    initialization_options = InitializationOptions.model_validate(
+    initialization_options = initialization_options_converter.structure(
         {
             "completion": {
                 "resolveEagerly": True,
@@ -25,6 +28,7 @@ def test_initialization_options() -> None:
             },
             "extra": "ignored",
         },
+        InitializationOptions,
     )
 
     assert_that(initialization_options.completion.resolve_eagerly, is_(True))


### PR DESCRIPTION
This adds testing for parsing of the initialization options first with pydantic, then adapts the tests for the removal of pydantic and then fixes issues that the test finds within the parsing setup.

This is built on #282 and #281.

Note: the options parsing silently allows unexpected extra keys, which was what was creating confusion in #281. This PR does not change that.