### PR TITLE
Semantic highlighting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ See: <https://github.com/pappasam/jedi-language-server/issues/50#issuecomment-78
         "ignoreFolders": [".nox", ".tox", ".venv", "__pycache__", "venv"],
         "maxSymbols": 20
       }
+    },
+    "semanticTokens": {
+      "enable": false
     }
   }
 }
@@ -411,6 +414,16 @@ Performance optimization that sets names of folders that are ignored for `worksp
 
 If you manually set this option, it overrides the default. Setting it to an empty array will result in no ignored folders.
 
+### semanticTokens.enable
+
+Improves highlighting by providing semantic token information.
+
+- type: `boolean`
+- default: `false`
+
+Disabled by default for performance reasons.
+
+
 ## Diagnostics
 
 Diagnostics are provided by Python's built-in `compile` function.
@@ -465,6 +478,7 @@ jedi-language-server aims to support Jedi's capabilities and expose them through
 - [textDocument/publishDiagnostics](https://microsoft.github.io/language-server-protocol/specification#textDocument_publishDiagnostics)
 - [textDocument/references](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references)
 - [textDocument/rename](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rename)
+- [textDocument/semanticTokens](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_semanticTokens)
 - [textDocument/signatureHelp](https://microsoft.github.io/language-server-protocol/specification#textDocument_signatureHelp)
 - [workspace/symbol](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_symbol)
 

--- a/jedi_language_server/constants.py
+++ b/jedi_language_server/constants.py
@@ -1,4 +1,17 @@
 """Constants."""
 
+from lsprotocol.types import SemanticTokenTypes
+
 MAX_CONCURRENT_DEBOUNCE_CALLS = 10
 """The maximum number of concurrent calls allowed by the debounce decorator."""
+
+_token_types = list(SemanticTokenTypes)
+
+TYPE_TO_TOKEN_ID = {
+    "module": _token_types.index(SemanticTokenTypes.Namespace),
+    "class": _token_types.index(SemanticTokenTypes.Class),
+    "function": _token_types.index(SemanticTokenTypes.Function),
+    "param": _token_types.index(SemanticTokenTypes.Parameter),
+    "statement": _token_types.index(SemanticTokenTypes.Variable),
+    "property": _token_types.index(SemanticTokenTypes.Property),
+}

--- a/jedi_language_server/constants.py
+++ b/jedi_language_server/constants.py
@@ -5,15 +5,17 @@ from lsprotocol.types import SemanticTokenTypes
 MAX_CONCURRENT_DEBOUNCE_CALLS = 10
 """The maximum number of concurrent calls allowed by the debounce decorator."""
 
-_token_types = list(SemanticTokenTypes)
-
-SEMANTIC_TO_TOKEN_ID = {
-    "module": _token_types.index(SemanticTokenTypes.Namespace),
-    "class": _token_types.index(SemanticTokenTypes.Class),
-    "function": _token_types.index(SemanticTokenTypes.Function),
-    "param": _token_types.index(SemanticTokenTypes.Parameter),
-    "statement": _token_types.index(SemanticTokenTypes.Variable),
-    "property": _token_types.index(SemanticTokenTypes.Property),
+SEMANTIC_TO_TOKEN_TYPE = {
+    "module": SemanticTokenTypes.Namespace,
+    "class": SemanticTokenTypes.Class,
+    "function": SemanticTokenTypes.Function,
+    "param": SemanticTokenTypes.Parameter,
+    "statement": SemanticTokenTypes.Variable,
+    "property": SemanticTokenTypes.Property,
 }
 
-SUPPORTED_SEMANTIC_TYPES = list(map(lambda t: t.value, _token_types))
+SUPPORTED_SEMANTIC_TYPES = [t.value for t in SEMANTIC_TO_TOKEN_TYPE.values()]
+
+SEMANTIC_TO_TOKEN_ID = {
+    key: index for index, key in enumerate(SEMANTIC_TO_TOKEN_TYPE.keys())
+}

--- a/jedi_language_server/constants.py
+++ b/jedi_language_server/constants.py
@@ -7,7 +7,7 @@ MAX_CONCURRENT_DEBOUNCE_CALLS = 10
 
 _token_types = list(SemanticTokenTypes)
 
-TYPE_TO_TOKEN_ID = {
+SEMANTIC_TO_TOKEN_ID = {
     "module": _token_types.index(SemanticTokenTypes.Namespace),
     "class": _token_types.index(SemanticTokenTypes.Class),
     "function": _token_types.index(SemanticTokenTypes.Function),
@@ -15,3 +15,5 @@ TYPE_TO_TOKEN_ID = {
     "statement": _token_types.index(SemanticTokenTypes.Variable),
     "property": _token_types.index(SemanticTokenTypes.Property),
 }
+
+SUPPORTED_SEMANTIC_TYPES = list(map(lambda t: t.value, _token_types))

--- a/jedi_language_server/initialization_options.py
+++ b/jedi_language_server/initialization_options.py
@@ -98,6 +98,11 @@ class Workspace:
 
 
 @light_dataclass
+class SemanticTokens:
+    enable: bool = False
+
+
+@light_dataclass
 class InitializationOptions:
     code_action: CodeAction = field(default_factory=CodeAction)
     completion: Completion = field(default_factory=Completion)
@@ -106,6 +111,7 @@ class InitializationOptions:
     jedi_settings: JediSettings = field(default_factory=JediSettings)
     markup_kind_preferred: Optional[MarkupKind] = None
     workspace: Workspace = field(default_factory=Workspace)
+    semantic_tokens: SemanticTokens = field(default_factory=SemanticTokens)
 
 
 initialization_options_converter = Converter()

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -92,7 +92,7 @@ from pygls.protocol import LanguageServerProtocol, lsp_method
 from pygls.server import LanguageServer
 
 from . import jedi_utils, notebook_utils, pygls_utils, text_edit_utils
-from .constants import TYPE_TO_TOKEN_ID
+from .constants import SEMANTIC_TO_TOKEN_ID, SUPPORTED_SEMANTIC_TYPES
 from .initialization_options import (
     InitializationOptions,
     initialization_options_converter,
@@ -772,7 +772,7 @@ def _raw_semantic_token(
 
     definition, *_ = definitions
     if (
-        definition_type := TYPE_TO_TOKEN_ID.get(definition.type, None)
+        definition_type := SEMANTIC_TO_TOKEN_ID.get(definition.type, None)
     ) is None:
         server.show_message_log(
             f"no matching semantic token for name {n.description} ({n.line}:{n.column})",
@@ -787,7 +787,7 @@ def _raw_semantic_token(
 @SERVER.feature(
     TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL,
     SemanticTokensLegend(
-        token_types=list(SemanticTokenTypes), token_modifiers=[]
+        token_types=SUPPORTED_SEMANTIC_TYPES, token_modifiers=[]
     ),
 )
 def semantic_tokens_full(
@@ -813,7 +813,7 @@ def semantic_tokens_full(
 @SERVER.feature(
     TEXT_DOCUMENT_SEMANTIC_TOKENS_RANGE,
     SemanticTokensLegend(
-        token_types=list(SemanticTokenTypes), token_modifiers=[]
+        token_types=SUPPORTED_SEMANTIC_TYPES, token_modifiers=[]
     ),
 )
 def semantic_tokens_range(
@@ -839,7 +839,7 @@ def _semantic_tokens_range(
     names = jedi_script.get_names(
         all_scopes=True, definitions=True, references=True
     )
-    data = []
+    data: list[int] = []
 
     for n in names:
         if (

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -759,23 +759,24 @@ def _raw_semantic_token(
     )
     if not definitions:
         server.show_message_log(
-            f"no definitions found for name {n.description} ({n.line}:{n.column})",
+            f"no definitions found for name \"{n.description}\" of type '{n.type}' ({n.line}:{n.column})",
             MessageType.Debug,
         )
         return None
 
     if len(definitions) > 1:
-        server.show_message_log(
-            f"multiple definitions found for name {n.description} ({n.line}:{n.column})",
-            MessageType.Debug,
+        msg = (
+            f"multiple definitions found for name \"{n.description}\" of type '{n.type}' ({n.line}:{n.column}):\n"
+            f" {"\n".join(map(lambda n: str(n), definitions))}"
         )
+        server.show_message_log(msg, MessageType.Debug)
 
     definition, *_ = definitions
     if (
         definition_type := SEMANTIC_TO_TOKEN_ID.get(definition.type, None)
     ) is None:
         server.show_message_log(
-            f"no matching semantic token for name {n.description} ({n.line}:{n.column})",
+            f"no matching semantic token for \"{n.description}\" of type '{n.type}' ({n.line}:{n.column})",
             MessageType.Debug,
         )
         return None
@@ -851,10 +852,10 @@ def _semantic_tokens_range(
 
         token = _raw_semantic_token(server, n)
 
-        server.show_message_log(
-            f"raw token for name {n.description} ({n.line - 1}:{n.column}): {token}",
-            MessageType.Debug,
-        )
+        # server.show_message_log(
+        #     f"raw token for name {n.description} ({n.line - 1}:{n.column}): {token}",
+        #     MessageType.Debug,
+        # )
         if token is None:
             continue
 
@@ -869,10 +870,10 @@ def _semantic_tokens_range(
         token[0] = delta_line
         token[1] = delta_column
 
-        server.show_message_log(
-            f"diff token for name {n.description} ({n.line - 1}:{n.column}): {token}",
-            MessageType.Debug,
-        )
+        # server.show_message_log(
+        #     f"diff token for name {n.description} ({n.line - 1}:{n.column}): {token}",
+        #     MessageType.Debug,
+        # )
         data.extend(token)
 
     return SemanticTokens(data=data)

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -767,9 +767,12 @@ def _raw_semantic_token(
         return None
 
     if len(definitions) > 1:
+        def_lines = "\n".join(
+            map(lambda n: str(n), definitions)
+        )  # f-string expression part cannot include a backslash
         msg = (
             f"multiple definitions found for name \"{n.description}\" of type '{n.type}' ({n.line}:{n.column}):\n"
-            f" {'\n'.join(map(lambda n: str(n), definitions))}"
+            f" {def_lines}"
         )
         server.show_message_log(msg, MessageType.Debug)
 

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -774,9 +774,8 @@ def _raw_semantic_token(
         server.show_message_log(msg, MessageType.Debug)
 
     definition, *_ = definitions
-    if (
-        definition_type := SEMANTIC_TO_TOKEN_ID.get(definition.type, None)
-    ) is None:
+    definition_type = SEMANTIC_TO_TOKEN_ID.get(definition.type, None)
+    if definition_type is None:
         server.show_message_log(
             f"no matching semantic token for \"{n.description}\" of type '{n.type}' ({n.line}:{n.column})",
             MessageType.Debug,

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -77,7 +77,6 @@ from lsprotocol.types import (
     SemanticTokensLegend,
     SemanticTokensParams,
     SemanticTokensRangeParams,
-    SemanticTokenTypes,
     SignatureHelp,
     SignatureHelpOptions,
     SignatureInformation,
@@ -92,7 +91,10 @@ from pygls.protocol import LanguageServerProtocol, lsp_method
 from pygls.server import LanguageServer
 
 from . import jedi_utils, notebook_utils, pygls_utils, text_edit_utils
-from .constants import SEMANTIC_TO_TOKEN_ID, SUPPORTED_SEMANTIC_TYPES
+from .constants import (
+    SEMANTIC_TO_TOKEN_ID,
+    SUPPORTED_SEMANTIC_TYPES,
+)
 from .initialization_options import (
     InitializationOptions,
     initialization_options_converter,
@@ -767,7 +769,7 @@ def _raw_semantic_token(
     if len(definitions) > 1:
         msg = (
             f"multiple definitions found for name \"{n.description}\" of type '{n.type}' ({n.line}:{n.column}):\n"
-            f" {"\n".join(map(lambda n: str(n), definitions))}"
+            f" {'\n'.join(map(lambda n: str(n), definitions))}"
         )
         server.show_message_log(msg, MessageType.Debug)
 

--- a/jedi_language_server/server.py
+++ b/jedi_language_server/server.py
@@ -188,6 +188,17 @@ class JediLanguageServerProtocol(LanguageServerProtocol):
         if server.initialization_options.hover.enable:
             server.feature(TEXT_DOCUMENT_HOVER)(hover)
 
+        if server.initialization_options.semantic_tokens.enable:
+            tokens_legend = SemanticTokensLegend(
+                token_types=SUPPORTED_SEMANTIC_TYPES, token_modifiers=[]
+            )
+            server.feature(TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL, tokens_legend)(
+                semantic_tokens_full
+            )
+            server.feature(TEXT_DOCUMENT_SEMANTIC_TOKENS_RANGE, tokens_legend)(
+                semantic_tokens_range
+            )
+
         initialize_result: InitializeResult = super().lsp_initialize(params)
         workspace_options = initialization_options.workspace
         server.project = (
@@ -809,12 +820,6 @@ def _raw_semantic_token(
 
 
 @SERVER.thread()
-@SERVER.feature(
-    TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL,
-    SemanticTokensLegend(
-        token_types=SUPPORTED_SEMANTIC_TYPES, token_modifiers=[]
-    ),
-)
 def semantic_tokens_full(
     server: JediLanguageServer, params: SemanticTokensParams
 ) -> SemanticTokens:
@@ -835,12 +840,6 @@ def semantic_tokens_full(
 
 
 @SERVER.thread()
-@SERVER.feature(
-    TEXT_DOCUMENT_SEMANTIC_TOKENS_RANGE,
-    SemanticTokensLegend(
-        token_types=SUPPORTED_SEMANTIC_TYPES, token_modifiers=[]
-    ),
-)
 def semantic_tokens_range(
     server: JediLanguageServer, params: SemanticTokensRangeParams
 ) -> SemanticTokens:

--- a/tests/lsp_test_client/session.py
+++ b/tests/lsp_test_client/session.py
@@ -191,6 +191,21 @@ class LspSession(MethodDispatcher):
         )
         return fut.result()
 
+    def text_doc_semantic_tokens_full(self, semantic_tokens_params):
+        """Sends text document semantic tokens full request to LSP server."""
+        fut = self._send_request(
+            "textDocument/semanticTokens/full", params=semantic_tokens_params
+        )
+        return fut.result()
+
+    def text_doc_semantic_tokens_range(self, semantic_tokens_range_params):
+        """Sends text document semantic tokens range request to LSP server."""
+        fut = self._send_request(
+            "textDocument/semanticTokens/range",
+            params=semantic_tokens_range_params,
+        )
+        return fut.result()
+
     def workspace_symbol(self, workspace_symbol_params):
         """Sends workspace symbol request to LSP server."""
         fut = self._send_request(

--- a/tests/lsp_tests/test_semantic_tokens.py
+++ b/tests/lsp_tests/test_semantic_tokens.py
@@ -56,10 +56,10 @@ def test_semantic_tokens_full_import_from():
             "data": [
                 0, 5, 2, 0, 0,  # "from os."
                 0, 3, 4, 0, 0,  # "path import "
-                0, 12, 6, 12, 0,  # "exists"
+                0, 12, 6, 2, 0,  # "exists"
                 1, 5, 3, 0, 0,  # "from sys import"
-                0, 11, 4, 8, 0,  # "argv as "
-                0, 8, 9, 8, 0,  # "arguments"
+                0, 11, 4, 4, 0,  # "argv as "
+                0, 8, 9, 4, 0,  # "arguments"
             ]
         }
         # fmt: on
@@ -88,8 +88,8 @@ def test_semantic_tokens_range_import_from():
         expected = {
             "data": [
                 0, 4, 3, 0, 0,  # "from sys import"
-                0, 11, 4, 8, 0,  # "argv as "
-                0, 8, 9, 8, 0,  # "arguments"
+                0, 11, 4, 4, 0,  # "argv as "
+                0, 8, 9, 4, 0,  # "arguments"
             ]
         }
         # fmt: on

--- a/tests/lsp_tests/test_semantic_tokens.py
+++ b/tests/lsp_tests/test_semantic_tokens.py
@@ -1,0 +1,96 @@
+"""Tests for semantic tokens requests."""
+
+from hamcrest import assert_that, is_
+
+from tests import TEST_DATA
+from tests.lsp_test_client import session
+from tests.lsp_test_client.utils import as_uri
+
+SEMANTIC_TEST_ROOT = TEST_DATA / "semantic_tokens"
+
+
+def test_semantic_tokens_full_import():
+    """Tests tokens for 'import name1 as name2'.
+
+    Test Data: tests/test_data/semantic_tokens/semantic_tokens_test1.py.
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        uri = as_uri(SEMANTIC_TEST_ROOT / "semantic_tokens_test1.py")
+        actual = ls_session.text_doc_semantic_tokens_full(
+            {
+                "textDocument": {"uri": uri},
+            }
+        )
+        # fmt: off
+        # [line, column, length, id, mod_id]
+        expected = {
+            "data": [
+                5, 7, 2, 0, 0,  # "import re"
+                1, 7, 3, 0, 0,  # "import sys, "
+                0, 5, 2, 0, 0,  # "os."
+                0, 3, 4, 0, 0,  # "path as "
+                0, 8, 4, 0, 0,  # "path"
+            ]
+        }
+        # fmt: on
+        assert_that(actual, is_(expected))
+
+
+def test_semantic_tokens_full_import_from():
+    """Tests tokens for 'from name1 import name2 as name3'.
+
+    Test Data: tests/test_data/semantic_tokens/semantic_tokens_test2.py.
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        uri = as_uri(SEMANTIC_TEST_ROOT / "semantic_tokens_test2.py")
+        actual = ls_session.text_doc_semantic_tokens_full(
+            {
+                "textDocument": {"uri": uri},
+            }
+        )
+        # fmt: off
+        # [line, column, length, id, mod_id]
+        expected = {
+            "data": [
+                0, 5, 2, 0, 0,  # "from os."
+                0, 3, 4, 0, 0,  # "path import "
+                0, 12, 6, 12, 0,  # "exists"
+                1, 5, 3, 0, 0,  # "from sys import"
+                0, 11, 4, 8, 0,  # "argv as "
+                0, 8, 9, 8, 0,  # "arguments"
+            ]
+        }
+        # fmt: on
+        assert_that(actual, is_(expected))
+
+
+def test_semantic_tokens_range_import_from():
+    """Tests tokens for 'from name1 import name2 as name3'.
+
+    Test Data: tests/test_data/semantic_tokens/semantic_tokens_test2.py.
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        uri = as_uri(SEMANTIC_TEST_ROOT / "semantic_tokens_test2.py")
+        actual = ls_session.text_doc_semantic_tokens_range(
+            {
+                "textDocument": {"uri": uri},
+                "range": {
+                    "start": {"line": 1, "character": 1},
+                    "end": {"line": 2, "character": 0},
+                },
+            }
+        )
+        # fmt: off
+        # [line, column, length, id, mod_id]
+        expected = {
+            "data": [
+                0, 4, 3, 0, 0,  # "from sys import"
+                0, 11, 4, 8, 0,  # "argv as "
+                0, 8, 9, 8, 0,  # "arguments"
+            ]
+        }
+        # fmt: on
+        assert_that(actual, is_(expected))

--- a/tests/test_data/semantic_tokens/semantic_tokens_test1.py
+++ b/tests/test_data/semantic_tokens/semantic_tokens_test1.py
@@ -1,0 +1,7 @@
+"""Test file for semantic tokens import.
+
+isort:skip_file
+"""
+
+import re
+import sys, os.path as path

--- a/tests/test_data/semantic_tokens/semantic_tokens_test2.py
+++ b/tests/test_data/semantic_tokens/semantic_tokens_test2.py
@@ -1,0 +1,2 @@
+from os.path import exists
+from sys import argv as arguments


### PR DESCRIPTION
Barebones implementation of `textDocument/semanticTokens/full` endpoint, with an unoptimal `textDocument/semanticTokens/range` as well. 
Detail could be improved by using `BaseName.infer()` over `BaseName.goto()` but neither method is ideal. Changes in Jedi APIs would probably be needed for a better solution (relying on private impl details was too painful).

Before and after:
![image](https://github.com/user-attachments/assets/3116f1b4-f2ba-47fb-b622-af11150250f1)

Fixes issue https://github.com/pappasam/jedi-language-server/issues/137 and https://github.com/pappasam/jedi-language-server/issues/336

Tests were based on PR https://github.com/pappasam/jedi-language-server/pull/231